### PR TITLE
Fix config flow schema serialization error for postcode support

### DIFF
--- a/custom_components/ha_bom_australia/manifest.json
+++ b/custom_components/ha_bom_australia/manifest.json
@@ -10,6 +10,6 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "codeowners": ["@safepay"]
 }


### PR DESCRIPTION
Bug Fix:
- Fixed ValueError: "Unable to convert schema: Any(<class 'float'>, '', msg=None)"
- Changed latitude/longitude fields from vol.Any(float, "") to cv.string
- Updated validation logic to properly handle string inputs and convert to floats
- Improved error handling for empty or invalid coordinate inputs

Changes:
- Use cv.string for optional lat/long fields (serializable by voluptuous)
- Parse and validate string inputs in processing logic
- Better validation flow: postcode → lat/long strings → missing location
- Strip whitespace from postcode input
- Proper float conversion with try/except for coordinates

Version bumped to 1.3.1