### PR TITLE
Improve postcode UX with checkbox to preserve default lat/long pre-po…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,17 +107,20 @@ After you have installed the custom component (see above):
 2. On the bottom right of the page, click on the `+ Add Integration` sign to add an integration.
 3. Search for `BOM Australia`. (If you don't see it, try refreshing your browser page to reload the cache.)
 4. Enter your location:
-   - **Option 1**: Enter latitude and longitude coordinates
-   - **Option 2**: Enter an Australian postcode (e.g., 3000 for Melbourne) - requires `pgeocode` library
+   - **Default**: Latitude and longitude fields are pre-populated with your Home Assistant's location - just click through to use your current location
+   - **Alternative**: Check "Use Australian postcode instead?" and enter a postcode (e.g., 3000 for Melbourne) to set up sensors for a different location
 5. The integration will display the nearest weather station and observation station being used
 6. Configure which entities you want to create (weather, observations, forecasts, warnings)
 7. Click `Submit` to add the integration.
 
-### Postcode Support (Optional)
+### Postcode Support
 
-The integration supports Australian postcode lookup for easier configuration. The `pgeocode` library will be automatically installed when using HACS or manual installation. If postcode lookup fails, you can always fall back to latitude/longitude coordinates.
+The integration supports Australian postcode lookup for easier configuration. This is especially useful when:
+- Setting up sensors for multiple locations (e.g., Melbourne and Sydney)
+- You don't know the exact coordinates but know the postcode
+- You want to quickly add a location without looking up coordinates
 
-**Note**: On first use, `pgeocode` will download a small Australian postcode database from GeoNames.org. This requires internet access and may take a moment.
+**Note**: On first use, `pgeocode` will download a small Australian postcode database from GeoNames.org (~2MB, one-time). This requires internet access and may take a moment.
 
 ## Troubleshooting
 

--- a/custom_components/ha_bom_australia/manifest.json
+++ b/custom_components/ha_bom_australia/manifest.json
@@ -10,6 +10,6 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "version": "1.3.1",
+  "version": "1.3.2",
   "codeowners": ["@safepay"]
 }

--- a/custom_components/ha_bom_australia/strings.json
+++ b/custom_components/ha_bom_australia/strings.json
@@ -3,11 +3,12 @@
     "step": {
       "user": {
         "title": "Set Up BOM Australia",
-        "description": "Enter your location using either coordinates OR Australian postcode to find the nearest Bureau of Meteorology weather station.\n\nYou can provide:\n  • Latitude and Longitude, OR\n  • Australian Postcode (e.g., 3000 for Melbourne)",
+        "description": "Enter your location to find the nearest Bureau of Meteorology weather station.\n\nBy default, your Home Assistant location is used. Alternatively, you can check the box below to search by Australian postcode instead.",
         "data": {
-          "latitude": "Latitude (or leave blank if using postcode)",
-          "longitude": "Longitude (or leave blank if using postcode)",
-          "postcode": "Australian Postcode (optional, overrides lat/long)"
+          "latitude": "Latitude",
+          "longitude": "Longitude",
+          "use_postcode": "Use Australian postcode instead?",
+          "postcode": "Australian Postcode (e.g., 3000 for Melbourne)"
         }
       },
       "weather_name": {
@@ -205,7 +206,7 @@
     "cannot_connect": "Failed to connect to Bureau of Meteorology",
     "unknown": "Unexpected error occurred",
     "invalid_postcode": "Invalid Australian postcode. Please check and try again.",
-    "missing_location": "Please provide either latitude/longitude OR a postcode",
+    "postcode_required": "Please enter an Australian postcode when 'Use postcode' is checked.",
     "invalid_coords": "Invalid coordinates. Please check latitude and longitude values."
   },
   "abort": {


### PR DESCRIPTION
…pulation

User Experience Improvements:
- Latitude/longitude fields now pre-populated with Home Assistant location (default behavior restored)
- Added "Use Australian postcode instead?" checkbox for opt-in postcode lookup
- Users can now simply click through to use their HA location (no need to enter anything)
- Postcode field only used when checkbox is checked
- No need to delete/clear lat/long values when using postcode

Changes:
- Modified config flow schema to use checkbox for postcode toggle
- Lat/long fields remain as required floats with HA default values
- Postcode lookup only triggers when "use_postcode" checkbox is checked
- Updated validation logic to check checkbox state
- Added "postcode_required" error when checkbox is checked but postcode is empty
- Updated strings.json with clearer descriptions and checkbox label
- Updated README to reflect improved UX flow

Benefits:
- Most users can just click through without entering anything (uses HA location)
- Users wanting different location can check box and enter postcode
- Maintains original simplicity while adding postcode convenience
- Better user experience for both simple and advanced use cases

Version bumped to 1.3.2