### PR TITLE
Add missing human-readable labels for forecast sensors

### DIFF
--- a/custom_components/ha_bom_australia/manifest.json
+++ b/custom_components/ha_bom_australia/manifest.json
@@ -11,6 +11,6 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "version": "1.3.7",
+  "version": "1.3.8",
   "codeowners": ["@safepay"]
 }

--- a/custom_components/ha_bom_australia/strings.json
+++ b/custom_components/ha_bom_australia/strings.json
@@ -84,6 +84,7 @@
           "uv_max_index": "UV Max Index",
           "uv_start_time": "UV Protection Start Time",
           "uv_end_time": "UV Protection End Time",
+          "uv_forecast": "UV Forecast Summary",
           "rain_amount_min": "Rain Amount (Minimum)",
           "rain_amount_max": "Rain Amount (Maximum)",
           "rain_amount_range": "Rain Amount Range",
@@ -93,6 +94,8 @@
           "now_temp_now": "Now Temperature",
           "now_later_label": "Later Label",
           "now_temp_later": "Later Temperature",
+          "astronomical_sunrise_time": "Sunrise Time",
+          "astronomical_sunset_time": "Sunset Time",
           "forecasts_days": "Number of Forecast Days (0-7)"
         }
       }
@@ -181,6 +184,7 @@
           "uv_max_index": "UV Max Index",
           "uv_start_time": "UV Protection Start Time",
           "uv_end_time": "UV Protection End Time",
+          "uv_forecast": "UV Forecast Summary",
           "rain_amount_min": "Rain Amount (Minimum)",
           "rain_amount_max": "Rain Amount (Maximum)",
           "rain_amount_range": "Rain Amount Range",
@@ -190,6 +194,8 @@
           "now_temp_now": "Now Temperature",
           "now_later_label": "Later Label",
           "now_temp_later": "Later Temperature",
+          "astronomical_sunrise_time": "Sunrise Time",
+          "astronomical_sunset_time": "Sunset Time",
           "forecasts_days": "Number of Forecast Days (0-7)"
         }
       }

--- a/custom_components/ha_bom_australia/translations/en.json
+++ b/custom_components/ha_bom_australia/translations/en.json
@@ -84,6 +84,7 @@
           "uv_max_index": "UV Max Index",
           "uv_start_time": "UV Protection Start Time",
           "uv_end_time": "UV Protection End Time",
+          "uv_forecast": "UV Forecast Summary",
           "rain_amount_min": "Rain Amount (Minimum)",
           "rain_amount_max": "Rain Amount (Maximum)",
           "rain_amount_range": "Rain Amount Range",
@@ -93,6 +94,8 @@
           "now_temp_now": "Now Temperature",
           "now_later_label": "Later Label",
           "now_temp_later": "Later Temperature",
+          "astronomical_sunrise_time": "Sunrise Time",
+          "astronomical_sunset_time": "Sunset Time",
           "forecasts_days": "Number of Forecast Days (0-7)"
         }
       }
@@ -181,6 +184,7 @@
           "uv_max_index": "UV Max Index",
           "uv_start_time": "UV Protection Start Time",
           "uv_end_time": "UV Protection End Time",
+          "uv_forecast": "UV Forecast Summary",
           "rain_amount_min": "Rain Amount (Minimum)",
           "rain_amount_max": "Rain Amount (Maximum)",
           "rain_amount_range": "Rain Amount Range",
@@ -190,6 +194,8 @@
           "now_temp_now": "Now Temperature",
           "now_later_label": "Later Label",
           "now_temp_later": "Later Temperature",
+          "astronomical_sunrise_time": "Sunrise Time",
+          "astronomical_sunset_time": "Sunset Time",
           "forecasts_days": "Number of Forecast Days (0-7)"
         }
       }


### PR DESCRIPTION
- Added "UV Forecast Summary" label for uv_forecast
- Added "Sunrise Time" label for astronomical_sunrise_time
- Added "Sunset Time" label for astronomical_sunset_time
- Updated both strings.json and translations/en.json
- Version bumped to 1.3.8

These fields were showing as raw keys in the forecast config flow instead of human-readable labels.