### PR TITLE
Fix Delta-T sensor calculation order bug

### DIFF
--- a/custom_components/ha_bom_australia/PyBoM/collector.py
+++ b/custom_components/ha_bom_australia/PyBoM/collector.py
@@ -201,17 +201,6 @@ class Collector:
                         self.observations_data["data"]["gust_speed_kilometre"] = "unavailable"
                         self.observations_data["data"]["gust_speed_knot"] = "unavailable"
 
-                    # Calculate Delta-T (temperature - dew point)
-                    temp = self.observations_data["data"].get("temp")
-                    dew_point = self.observations_data["data"].get("dew_point")
-                    if temp is not None and dew_point is not None:
-                        try:
-                            self.observations_data["data"]["delta_t"] = round(temp - dew_point, 1)
-                        except (TypeError, ValueError):
-                            self.observations_data["data"]["delta_t"] = None
-                    else:
-                        self.observations_data["data"]["delta_t"] = None
-
                     # Calculate dew point using Magnus-Tetens formula
                     temp = self.observations_data["data"].get("temp")
                     humidity = self.observations_data["data"].get("humidity")
@@ -228,6 +217,17 @@ class Collector:
                             self.observations_data["data"]["dew_point"] = None
                     else:
                         self.observations_data["data"]["dew_point"] = None
+
+                    # Calculate Delta-T (temperature - dew point)
+                    temp = self.observations_data["data"].get("temp")
+                    dew_point = self.observations_data["data"].get("dew_point")
+                    if temp is not None and dew_point is not None:
+                        try:
+                            self.observations_data["data"]["delta_t"] = round(temp - dew_point, 1)
+                        except (TypeError, ValueError):
+                            self.observations_data["data"]["delta_t"] = None
+                    else:
+                        self.observations_data["data"]["delta_t"] = None
 
                 # Get daily forecast data
                 data = await self._fetch_with_retry(


### PR DESCRIPTION
Issue: Delta-T sensors were returning "unknown" because delta_t was calculated before dew_point, so dew_point didn't exist yet.

Fix: Swap the calculation order so dew_point is calculated first using the Magnus-Tetens formula, then delta_t can correctly use that value.

Delta-T = temperature - dew_point (used for fire weather assessment)