### PR TITLE
Add fire_weather_warning to warning sensors

### DIFF
--- a/custom_components/ha_bom_australia/const.py
+++ b/custom_components/ha_bom_australia/const.py
@@ -338,4 +338,5 @@ WARNING_TYPES: Final = {
     "heatwave_warning": {"name": "Heatwave Warning", "icon": "mdi:thermometer-alert"},
     "frost_warning": {"name": "Frost Warning", "icon": "mdi:snowflake-alert"},
     "bushwalkers_alert": {"name": "Bushwalkers Alert", "icon": "mdi:hiking"},
+    "fire_weather_warning": {"name": "Fire Weather Warning", "icon": "mdi:fire-alert"},
 }

--- a/custom_components/ha_bom_australia/strings.json
+++ b/custom_components/ha_bom_australia/strings.json
@@ -70,7 +70,8 @@
           "hazardous_surf_warning": "Hazardous Surf Warning",
           "heatwave_warning": "Heatwave Warning",
           "frost_warning": "Frost Warning",
-          "bushwalkers_alert": "Bushwalkers Alert"
+          "bushwalkers_alert": "Bushwalkers Alert",
+          "fire_weather_warning": "Fire Weather Warning"
         }
       },
       "forecasts_monitored": {
@@ -173,7 +174,8 @@
           "hazardous_surf_warning": "Hazardous Surf Warning",
           "heatwave_warning": "Heatwave Warning",
           "frost_warning": "Frost Warning",
-          "bushwalkers_alert": "Bushwalkers Alert"
+          "bushwalkers_alert": "Bushwalkers Alert",
+          "fire_weather_warning": "Fire Weather Warning"
         }
       },
       "forecasts_monitored": {

--- a/custom_components/ha_bom_australia/translations/en.json
+++ b/custom_components/ha_bom_australia/translations/en.json
@@ -70,7 +70,8 @@
           "hazardous_surf_warning": "Hazardous Surf Warning",
           "heatwave_warning": "Heatwave Warning",
           "frost_warning": "Frost Warning",
-          "bushwalkers_alert": "Bushwalkers Alert"
+          "bushwalkers_alert": "Bushwalkers Alert",
+          "fire_weather_warning": "Fire Weather Warning"
         }
       },
       "forecasts_monitored": {
@@ -173,7 +174,8 @@
           "hazardous_surf_warning": "Hazardous Surf Warning",
           "heatwave_warning": "Heatwave Warning",
           "frost_warning": "Frost Warning",
-          "bushwalkers_alert": "Bushwalkers Alert"
+          "bushwalkers_alert": "Bushwalkers Alert",
+          "fire_weather_warning": "Fire Weather Warning"
         }
       },
       "forecasts_monitored": {


### PR DESCRIPTION
Changes:
- Add fire_weather_warning to WARNING_TYPES dictionary with mdi:fire-alert icon
- Add fire_weather_warning option to config flow in strings.json
- Add fire_weather_warning option to config flow in translations/en.json

Users can now create binary sensors that alert when BOM issues fire weather warnings. This warning type has been confirmed from actual BOM API responses.