### PR TITLE
Fix geohash variable naming and document API quirks

### DIFF
--- a/api doc/API.md
+++ b/api doc/API.md
@@ -2,7 +2,12 @@
 
 This folder contains documentation for the Bureau of Meteorology's undocumented APIs. These APIs are used by the BOM mobile app and https://weather.bom.gov.au.
 
-All APIs return JSON data. Location selection uses a 7-character geohash.
+All APIs return JSON data. Location selection uses geohashes for precision targeting.
+
+**Geohash Requirements:**
+- **Hourly forecasts:** Requires 6-character geohash (7-char returns error)
+- **Daily forecasts, warnings, observations:** Accept both 6 or 7-character geohash
+- **Recommendation:** Use 6-character geohash for all endpoints as the common denominator
 
 ## Location Search
 


### PR DESCRIPTION
Changes:
- Renamed geohash7/geohash6 to just 'geohash' (always 6 chars)
- Explicitly set precision=6 in geohash_encode call
- Added comment explaining BOM API's inconsistent geohash requirements
- Updated API.md to document that hourly forecasts require 6-char geohash
- Documented that daily/warnings accept 6 or 7-char geohash

This fixes the misleading variable names where 'geohash7' was actually generating 6-character geohashes due to the default precision parameter. The current behavior (using 6 chars) is correct since hourly forecasts require exactly 6 characters.