### PR TITLE
Add postcode location selection for precise warning zones

### DIFF
--- a/api doc/API.md
+++ b/api doc/API.md
@@ -11,6 +11,8 @@ All APIs return JSON data. Location selection uses geohashes for precision targe
 
 ## Location Search
 
+### Search by Coordinates
+
 Fetch the geohash for a given latitude/longitude.
 
 **Endpoint:** `https://api.weather.bom.gov.au/v1/locations?search={latitude},{longitude}`
@@ -35,6 +37,49 @@ Fetch the geohash for a given latitude/longitude.
   ]
 }
 ```
+
+### Search by Postcode
+
+Search for all locations within a specific Australian postcode. Returns multiple locations if the postcode covers multiple towns.
+
+**Endpoint:** `https://api.weather.bom.gov.au/v1/locations?search={postcode}`
+
+**Example:** `https://api.weather.bom.gov.au/v1/locations?search=4417`
+
+**Response:**
+```json
+{
+  "metadata": {
+    "response_timestamp": "2025-11-18T21:24:08Z",
+    "copyright": "..."
+  },
+  "data": [
+    {
+      "geohash": "r74n52x",
+      "id": "Noorindoo-r74n52x",
+      "name": "Noorindoo",
+      "postcode": "4417",
+      "state": "QLD"
+    },
+    {
+      "geohash": "r71yk13",
+      "id": "Oberina-r71yk13",
+      "name": "Oberina",
+      "postcode": "4417",
+      "state": "QLD"
+    },
+    {
+      "geohash": "r74j2pv",
+      "id": "Surat-r74j2pv",
+      "name": "Surat",
+      "postcode": "4417",
+      "state": "QLD"
+    }
+  ]
+}
+```
+
+**Note:** Each location within a postcode has its own unique geohash, which may result in different weather data and warnings. This is particularly important for warnings, as a single postcode can span multiple warning zones. Always select the specific town/location rather than relying on postcode-level geocoding.
 
 ## Location Info
 

--- a/custom_components/ha_bom_australia/PyBoM/collector.py
+++ b/custom_components/ha_bom_australia/PyBoM/collector.py
@@ -27,8 +27,17 @@ MAX_CACHE_AGE = 86400  # 24 hours in seconds
 class Collector:
     """Collector for PyBoM."""
 
-    def __init__(self, latitude: float, longitude: float) -> None:
-        """Init collector."""
+    def __init__(self, latitude: float, longitude: float, geohash: str | None = None) -> None:
+        """Init collector.
+
+        Args:
+            latitude: Latitude coordinate
+            longitude: Longitude coordinate
+            geohash: Optional BOM-provided geohash. If provided, this will be used
+                    instead of calculating one. This ensures we use the exact same
+                    geohash that BOM's location search returns, which may differ
+                    slightly from calculated values.
+        """
         self.latitude = latitude
         self.longitude = longitude
         self.locations_data = None
@@ -36,11 +45,16 @@ class Collector:
         self.daily_forecasts_data = None
         self.hourly_forecasts_data = None
         self.warnings_data = None
-        # BOM API has inconsistent geohash requirements:
-        # - Hourly forecasts: requires 6-char geohash
-        # - Daily forecasts/warnings: accepts 6 or 7-char geohash
-        # We use 6-char as the common denominator
-        self.geohash = geohash_encode(latitude, longitude, precision=6)
+
+        # Use provided geohash if available, otherwise calculate it
+        if geohash:
+            self.geohash = geohash
+        else:
+            # BOM API has inconsistent geohash requirements:
+            # - Hourly forecasts: requires 6-char geohash
+            # - Daily forecasts/warnings: accepts 6 or 7-char geohash
+            # We use 6-char as the common denominator when calculating
+            self.geohash = geohash_encode(latitude, longitude, precision=6)
         # Cache storage with timestamps
         self._cache = {
             "locations": {"data": None, "timestamp": 0},

--- a/custom_components/ha_bom_australia/PyBoM/helpers.py
+++ b/custom_components/ha_bom_australia/PyBoM/helpers.py
@@ -45,3 +45,39 @@ def geohash_encode(latitude: float, longitude: float, precision: int = 6) -> str
             bit = 0
             ch = 0
     return ''.join(geohash)
+
+def geohash_decode(geohash: str) -> tuple[float, float]:
+    """Decode geohash string to latitude/longitude.
+
+    Returns:
+        Tuple of (latitude, longitude) representing the center point of the geohash.
+    """
+    base32 = '0123456789bcdefghjkmnpqrstuvwxyz'
+    lat_interval = (-90.0, 90.0)
+    lon_interval = (-180.0, 180.0)
+    bits = [16, 8, 4, 2, 1]
+    even = True
+
+    for c in geohash:
+        idx = base32.index(c)
+        for mask in bits:
+            if even:
+                # Longitude bit
+                mid = (lon_interval[0] + lon_interval[1]) / 2
+                if idx & mask:
+                    lon_interval = (mid, lon_interval[1])
+                else:
+                    lon_interval = (lon_interval[0], mid)
+            else:
+                # Latitude bit
+                mid = (lat_interval[0] + lat_interval[1]) / 2
+                if idx & mask:
+                    lat_interval = (mid, lat_interval[1])
+                else:
+                    lat_interval = (lat_interval[0], mid)
+            even = not even
+
+    # Return center point of the geohash box
+    latitude = (lat_interval[0] + lat_interval[1]) / 2
+    longitude = (lon_interval[0] + lon_interval[1]) / 2
+    return latitude, longitude


### PR DESCRIPTION
Implements postcode-based setup with town selection to address the issue where warnings are tied to specific geographic areas and postcodes can span multiple warning zones.

Changes:
- Config flow: Added location selection step when multiple towns exist in a postcode
- Query BOM API /v1/locations?search={postcode} to get all towns in postcode
- Present dropdown for user to select their specific town
- Use BOM's official geohash from API instead of calculating one
- Collector: Accept optional geohash parameter to use BOM's exact values
- Helpers: Add geohash_decode() function to extract coordinates from geohash
- Options flow: Added same postcode location selection capability
- API.md: Document postcode search endpoint with examples

Benefits:
- Users get warnings for their actual location, not postcode centroid
- Solves issue where part of a postcode has warnings while other parts don't
- Uses BOM's canonical geohash values which may differ from calculated ones
- Single-location postcodes automatically proceed without extra selection step

Example: Postcode 4417 contains 7 towns with different geohashes and warning zones. User can now select their specific town (e.g., Surat) to get accurate warnings for their area.