### PR TITLE
Add translations for postcode location selection steps

### DIFF
--- a/custom_components/ha_bom_australia/translations/en.json
+++ b/custom_components/ha_bom_australia/translations/en.json
@@ -11,6 +11,13 @@
           "postcode": "Australian Postcode (e.g., 3000 for Melbourne)"
         }
       },
+      "select_location": {
+        "title": "Select Your Location",
+        "description": "Multiple locations found for postcode {postcode}. Please select your specific town or locality.\n\nNote: Each location has its own weather data and warning zone. Selecting the correct location ensures accurate warnings for your area.",
+        "data": {
+          "location_id": "Location"
+        }
+      },
       "weather_name": {
         "title": "Configure Entity Prefix",
         "description": "Nearest BOM location: {location_name}\nObservation station: {station_name} (ID: {station_id})\n\nChoose a prefix for all your BOM entities (weather, sensors, and warnings).\nExample with prefix '{default_prefix}':\n  • weather.{default_prefix}\n  • sensor.{default_prefix}_temp\n  • binary_sensor.{default_prefix}_warning_flood",
@@ -110,10 +117,19 @@
     "step": {
       "init": {
         "title": "Reconfigure Location",
-        "description": "Update your location coordinates to find a different Bureau of Meteorology weather station.",
+        "description": "Update your location coordinates to find a different Bureau of Meteorology weather station.\n\nBy default, enter coordinates directly. Alternatively, you can check the box below to search by Australian postcode instead.",
         "data": {
           "latitude": "Latitude",
-          "longitude": "Longitude"
+          "longitude": "Longitude",
+          "use_postcode": "Use Australian postcode instead?",
+          "postcode": "Australian Postcode (e.g., 3000 for Melbourne)"
+        }
+      },
+      "select_location": {
+        "title": "Select Your Location",
+        "description": "Multiple locations found for postcode {postcode}. Please select your specific town or locality.\n\nNote: Each location has its own weather data and warning zone. Selecting the correct location ensures accurate warnings for your area.",
+        "data": {
+          "location_id": "Location"
         }
       },
       "weather_name": {


### PR DESCRIPTION
Adds missing translation entries for the new select_location step in both config and options flows. Also updates the options init step description to mention postcode search capability.

Changes:
- config.step.select_location: Title, description, and location_id field
- options.step.select_location: Same translations as config flow
- options.step.init: Updated description and added postcode fields

The translation explains to users that multiple locations in a postcode may have different warning zones, helping them understand why specific location selection matters.