### PR TITLE
Fix geohash truncation for postcode search locations

### DIFF
--- a/api doc/API.md
+++ b/api doc/API.md
@@ -5,9 +5,12 @@ This folder contains documentation for the Bureau of Meteorology's undocumented 
 All APIs return JSON data. Location selection uses geohashes for precision targeting.
 
 **Geohash Requirements:**
-- **Hourly forecasts:** Requires 6-character geohash (7-char returns error)
-- **Daily forecasts, warnings, observations:** Accept both 6 or 7-character geohash
-- **Recommendation:** Use 6-character geohash for all endpoints as the common denominator
+- **Observations:** Requires **exactly 6-character geohash** (returns 400 error if not 6 chars)
+- **Hourly forecasts:** Requires **exactly 6-character geohash** (returns 400 error if not 6 chars)
+- **Daily forecasts, warnings:** Accept both 6 or 7-character geohash
+- **Location search (coordinates):** Returns 7-character geohash
+- **Location search (postcode):** Returns 7-character geohash
+- **Critical:** When using geohashes from location search, **truncate to 6 characters** before querying observations or hourly forecasts
 
 ## Location Search
 
@@ -79,7 +82,9 @@ Search for all locations within a specific Australian postcode. Returns multiple
 }
 ```
 
-**Note:** Each location within a postcode has its own unique geohash, which may result in different weather data and warnings. This is particularly important for warnings, as a single postcode can span multiple warning zones. Always select the specific town/location rather than relying on postcode-level geocoding.
+**Important Notes:**
+- **Geohash Length:** Postcode search returns **7-character geohashes**. However, observations and hourly forecast endpoints require **exactly 6 characters**. You must truncate the geohash to 6 chars (e.g., `r74n52x` → `r74n52`) when querying those endpoints.
+- **Warning Zones:** Each location within a postcode has its own unique geohash, which may result in different weather data and warnings. This is particularly important for warnings, as a single postcode can span multiple warning zones. Always select the specific town/location rather than relying on postcode-level geocoding.
 
 ## Location Info
 

--- a/custom_components/ha_bom_australia/PyBoM/collector.py
+++ b/custom_components/ha_bom_australia/PyBoM/collector.py
@@ -36,7 +36,8 @@ class Collector:
             geohash: Optional BOM-provided geohash. If provided, this will be used
                     instead of calculating one. This ensures we use the exact same
                     geohash that BOM's location search returns, which may differ
-                    slightly from calculated values.
+                    slightly from calculated values. Will be truncated to 6 chars
+                    if longer, as observations/hourly endpoints require exactly 6.
         """
         self.latitude = latitude
         self.longitude = longitude
@@ -48,11 +49,13 @@ class Collector:
 
         # Use provided geohash if available, otherwise calculate it
         if geohash:
-            self.geohash = geohash
+            # BOM postcode search returns 7-char geohashes, but observations and
+            # hourly endpoints require exactly 6 chars. Truncate if necessary.
+            self.geohash = geohash[:6]
         else:
             # BOM API has inconsistent geohash requirements:
-            # - Hourly forecasts: requires 6-char geohash
-            # - Daily forecasts/warnings: accepts 6 or 7-char geohash
+            # - Hourly forecasts: requires 6-character geohash
+            # - Daily forecasts/warnings: accepts 6 or 7-character geohash
             # We use 6-char as the common denominator when calculating
             self.geohash = geohash_encode(latitude, longitude, precision=6)
         # Cache storage with timestamps


### PR DESCRIPTION
The BOM postcode search API returns 7-character geohashes, but the observations and hourly forecast endpoints require exactly 6 characters. This was causing 400 errors when using postcode-selected locations.

Error was:
  "WEATHER-400: Invalid Geohash - The geohash string was not 6 character"

Solution:
- Truncate geohashes to 6 characters in Collector.__init__()
- When a 7-char geohash is provided (from postcode search), use first 6 chars
- Updated API.md to document this quirk and requirement

The truncation maintains location accuracy while ensuring API compatibility:
- 6-char geohash: ~1.2km × 0.6km precision
- 7-char geohash: ~153m × 153m precision
- Truncating loses minimal precision for weather data purposes

This fixes the "Unknown" station data issue when using postcode selection.