### PR TITLE
Fix default_prefix placeholder not being substituted in translations

### DIFF
--- a/custom_components/ha_bom_australia/translations/en.json
+++ b/custom_components/ha_bom_australia/translations/en.json
@@ -20,7 +20,7 @@
       },
       "weather_name": {
         "title": "Configure Entity Prefix",
-        "description": "Nearest BOM location: {location_name}\nObservation station: {station_name} (ID: {station_id})\n\nChoose a prefix for all your BOM entities (weather, sensors, and warnings).\nExample with prefix '{default_prefix}':\n  • weather.{default_prefix}\n  • sensor.{default_prefix}_temp\n  • binary_sensor.{default_prefix}_warning_flood",
+        "description": "Nearest BOM location: {location_name}\nObservation station: {station_name} (ID: {station_id})\n\nChoose a prefix for all your BOM entities (weather, sensors, and warnings).\nExample with prefix {default_prefix}:\n  • weather.{default_prefix}\n  • sensor.{default_prefix}_temp\n  • binary_sensor.{default_prefix}_warning_flood",
         "data": {
           "entity_prefix": "Entity Prefix (used for all BOM entities)"
         }
@@ -134,7 +134,7 @@
       },
       "weather_name": {
         "title": "Configure Entity Prefix",
-        "description": "Nearest BOM location: {location_name}\n\nChoose a prefix for all your BOM entities (weather, sensors, and warnings).\nExample with prefix '{default_prefix}':\n  • weather.{default_prefix}\n  • sensor.{default_prefix}_temp\n  • binary_sensor.{default_prefix}_warning_flood",
+        "description": "Nearest BOM location: {location_name}\n\nChoose a prefix for all your BOM entities (weather, sensors, and warnings).\nExample with prefix {default_prefix}:\n  • weather.{default_prefix}\n  • sensor.{default_prefix}_temp\n  • binary_sensor.{default_prefix}_warning_flood",
         "data": {
           "entity_prefix": "Entity Prefix (used for all BOM entities)"
         }


### PR DESCRIPTION
The single quotes around '{default_prefix}' in the weather_name step description were preventing the placeholder from being substituted by Home Assistant's translation system.

Issue: Text showed literal '{default_prefix}' instead of the actual value
Fix: Removed single quotes to allow proper placeholder substitution

Changed:
- 'Example with prefix '{default_prefix}':'
+ 'Example with prefix {default_prefix}:'

Applied to both config and options flows.