### PR TITLE
Remove pgeocode dependency in favor of BOM API postcode search

### DIFF
--- a/custom_components/ha_bom_australia/manifest.json
+++ b/custom_components/ha_bom_australia/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://github.com/safepay/ha_bom_australia",
   "issue_tracker": "https://github.com/safepay/ha_bom_australia/issues",
-  "requirements": ["iso8601", "pgeocode"],
+  "requirements": ["iso8601"],
   "icon": "mdi:weather-partly-cloudy",
   "ssdp": [],
   "zeroconf": [],


### PR DESCRIPTION
The integration now uses BOM's native postcode search API instead of the external pgeocode library. This simplifies dependencies and uses official BOM data for Australian postcodes.

Changes:
- Removed pgeocode from manifest.json requirements
- Removed pgeocode import and PGEOCODE_AVAILABLE flag from config_flow.py
- Postcode search option now always available (no conditional gating)
- Simplified config and options flow schema generation
- Reduced code complexity by removing conditional branches

Benefits:
- One less external dependency to install
- Uses BOM's official postcode-to-location mapping
- Returns multiple towns per postcode (better than pgeocode centroid)
- Consistent with using BOM API for all weather data

The postcode feature is now always available since it relies on the same BOM API that the integration already requires for weather data.