### PR TITLE
Remove invalid icon field from manifest.json

### DIFF
--- a/custom_components/ha_bom_australia/manifest.json
+++ b/custom_components/ha_bom_australia/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@safepay"],
   "config_flow": true,
   "documentation": "https://github.com/safepay/ha_bom_australia",
-  "icon": "mdi:weather-partly-cloudy",
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/safepay/ha_bom_australia/issues",


### PR DESCRIPTION
The icon field is not allowed in Home Assistant integration manifests and causes hassfest validation to fail. Icons are handled by Home Assistant's frontend automatically based on the integration type.