### PR TITLE
fix: declare the real minimum Home Assistant version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE.md)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2023.9.0+-blue.svg)](https://www.home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.11.0+-blue.svg)](https://www.home-assistant.io/)
 ![Maintenance](https://img.shields.io/maintenance/yes/2026)
 
 ### **This integration only supports locations within Australia.**

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Bureau of Meteorology",
   "render_readme": true,
-  "homeassistant": "2023.9.0"
+  "homeassistant": "2024.11.0"
 }

--- a/info.md
+++ b/info.md
@@ -3,7 +3,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE.md)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2023.9.0+-blue.svg)](https://www.home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.11.0+-blue.svg)](https://www.home-assistant.io/)
 ![Maintenance](https://img.shields.io/maintenance/yes/2026)
 
 [license-shield]: https://img.shields.io/github/license/safepay/ha_bom_australia.svg


### PR DESCRIPTION
## Problem

`hacs.json` and the Home Assistant badge in both `README.md` and `info.md` all claimed a minimum of **2023.9.0**. The integration has not actually run on a core that old for some time.

Two hard requirements in the current code:

1. **`BomOptionsFlow` (>= 2024.11)** — `config_flow.py` accepts `config_entry` in `__init__` and deliberately does not store it, then reads `self.config_entry` in ~20 places. `self.config_entry` only became a built-in property of plain `OptionsFlow` in [2024.11](https://developers.home-assistant.io/blog/2024/11/12/options-flow/). On 2024.10 or older, opening the options dialog raises `AttributeError` immediately.

2. **`DataUpdateCoordinator(config_entry=...)`** — `__init__.py` passes `config_entry=` explicitly, which is a 2024.x-era keyword. Older cores raise `TypeError` during setup.

## Change

Bump the declared floor to `2024.11.0` in all three places so it matches what the code requires. `2024.11.0` is the true floor — nothing in the codebase needs anything newer, so this locks out as few users as possible.

No behaviour change; documentation and metadata only.

## Note

HACS [does not reliably enforce](https://github.com/hacs/integration/issues/4243) the `homeassistant` key, so this will not hard-block installs on older cores. It is still worth declaring correctly: it is the only machine-readable signal available, and it makes the constraint explicit for anyone next editing the options flow.