### PR TITLE
fix: set config entry version via async_update_entry

### DIFF
--- a/custom_components/ha_bom_australia/__init__.py
+++ b/custom_components/ha_bom_australia/__init__.py
@@ -60,8 +60,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         if "forecasts_basename" in new:
             new[CONF_WEATHER_NAME] = config_entry.data["forecasts_basename"]
 
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data=new)
+        hass.config_entries.async_update_entry(config_entry, data=new, version=2)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True


### PR DESCRIPTION
`async_migrate_entry` set the entry version by direct assignment, which `ConfigEntry.__setattr__` rejects:

```
AttributeError: version cannot be changed directly, use async_update_entry instead
```

`version` is one of the persisted attributes that must be written through `async_update_entry` so the change reaches `.storage`. v1 entries therefore failed to migrate.

Passes `version=2` to the `async_update_entry` call that already writes the migrated data, so the schema bump and the data change land in one write.