### PR TITLE
fix: push forecast updates to weather card subscribers

### DIFF
--- a/custom_components/ha_bom_australia/weather.py
+++ b/custom_components/ha_bom_australia/weather.py
@@ -152,6 +152,10 @@ class WeatherBase(WeatherEntity):
     def _update_callback(self) -> None:
         """Load data from integration."""
         self.async_write_ha_state()
+        if entry := self.coordinator.config_entry:
+            entry.async_create_task(self.hass, self.async_update_listeners(None))
+            return
+        self.hass.async_create_task(self.async_update_listeners(None))
 
     @property
     def should_poll(self) -> bool:


### PR DESCRIPTION
The coordinator listener only called `async_write_ha_state()`, which republishes the state object but does not re-run `async_forecast_daily`/`async_forecast_hourly`. Forecasts reach the frontend over a websocket subscription served by those methods, so subscribers kept the forecast they were handed at subscribe time. `weather.get_forecasts` was unaffected, since it polls the methods directly.

Schedules `async_update_listeners(None)` alongside the state write, following core's `SingleCoordinatorWeatherEntity` — including its use of the config entry's task factory so the task is cancelled if the entry unloads.