### PR TITLE
fix: use Home Assistant's shared aiohttp session

### DIFF
--- a/custom_components/ha_bom_australia/PyBoM/collector.py
+++ b/custom_components/ha_bom_australia/PyBoM/collector.py
@@ -24,15 +24,25 @@ MAX_RETRIES = 3
 RETRY_DELAY_BASE = 2  # seconds
 MAX_CACHE_AGE = 86400  # 24 hours in seconds
 
+HEADERS = {"User-Agent": USER_AGENT}
+
 class Collector:
     """Collector for PyBoM."""
 
-    def __init__(self, latitude: float, longitude: float, geohash: str | None = None) -> None:
+    def __init__(
+        self,
+        latitude: float,
+        longitude: float,
+        session: aiohttp.ClientSession,
+        geohash: str | None = None,
+    ) -> None:
         """Init collector.
 
         Args:
             latitude: Latitude coordinate
             longitude: Longitude coordinate
+            session: Shared aiohttp session, owned by the caller. The collector
+                    never closes it.
             geohash: Optional BOM-provided geohash. If provided, this will be used
                     instead of calculating one. This ensures we use the exact same
                     geohash that BOM's location search returns, which may differ
@@ -41,6 +51,7 @@ class Collector:
         """
         self.latitude = latitude
         self.longitude = longitude
+        self._session = session
         self.locations_data = None
         self.observations_data = None
         self.daily_forecasts_data = None
@@ -67,11 +78,11 @@ class Collector:
             "warnings": {"data": None, "timestamp": 0},
         }
 
-    async def _fetch_with_retry(self, session: aiohttp.ClientSession, url: str, cache_key: str) -> dict[str, Any] | None:
+    async def _fetch_with_retry(self, url: str, cache_key: str) -> dict[str, Any] | None:
         """Fetch data with retry mechanism and store in cache if successful."""
         for attempt in range(MAX_RETRIES):
             try:
-                async with session.get(url) as response:
+                async with self._session.get(url, headers=HEADERS) as response:
                     if response.status == 200:
                         data = await response.json()
                         # Update cache with new data and timestamp
@@ -110,14 +121,10 @@ class Collector:
 
     async def get_locations_data(self) -> None:
         """Get JSON location name from BOM API endpoint."""
-        headers = {"User-Agent": USER_AGENT}
         try:
-            async with aiohttp.ClientSession(headers=headers) as session:
-                data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash, "locations"
-                )
-                if data:
-                    self.locations_data = data
+            data = await self._fetch_with_retry(URL_BASE + self.geohash, "locations")
+            if data:
+                self.locations_data = data
         except Exception as err:
             _LOGGER.error(f"Unexpected error in get_locations_data: {err}")
 
@@ -186,87 +193,84 @@ class Collector:
 
     async def async_update(self) -> None:
         """Refresh the data on the collector object."""
-        headers = {"User-Agent": USER_AGENT}
-        
         try:
-            async with aiohttp.ClientSession(headers=headers) as session:
-                # Get location data if not already available
-                if self.locations_data is None:
-                    data = await self._fetch_with_retry(
-                        session, URL_BASE + self.geohash, "locations"
-                    )
-                    if data:
-                        self.locations_data = data
-                
-                # Get observations data
+            # Get location data if not already available
+            if self.locations_data is None:
                 data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash + URL_OBSERVATIONS, "observations"
+                    URL_BASE + self.geohash, "locations"
                 )
                 if data:
-                    self.observations_data = data
-                    if self.observations_data["data"]["wind"] is not None:
-                        flatten_dict(["wind"], self.observations_data["data"])
-                    else:
-                        self.observations_data["data"]["wind_direction"] = "unavailable"
-                        self.observations_data["data"]["wind_speed_kilometre"] = "unavailable"
-                        self.observations_data["data"]["wind_speed_knot"] = "unavailable"
-                    if self.observations_data["data"]["gust"] is not None:
-                        flatten_dict(["gust"], self.observations_data["data"])
-                    else:
-                        self.observations_data["data"]["gust_speed_kilometre"] = "unavailable"
-                        self.observations_data["data"]["gust_speed_knot"] = "unavailable"
+                    self.locations_data = data
 
-                    # Calculate dew point using Magnus-Tetens formula
-                    temp = self.observations_data["data"].get("temp")
-                    humidity = self.observations_data["data"].get("humidity")
-                    if temp is not None and humidity is not None:
-                        try:
-                            # Magnus-Tetens approximation
-                            a = 17.27
-                            b = 237.7
-                            gamma = (a * temp / (b + temp)) + math.log(humidity / 100.0)
-                            dew_point = (b * gamma) / (a - gamma)
-                            self.observations_data["data"]["dew_point"] = round(dew_point, 1)
-                        except (TypeError, ValueError, ZeroDivisionError) as err:
-                            _LOGGER.debug(f"Error calculating dew point: {err}")
-                            self.observations_data["data"]["dew_point"] = None
-                    else:
+            # Get observations data
+            data = await self._fetch_with_retry(
+                URL_BASE + self.geohash + URL_OBSERVATIONS, "observations"
+            )
+            if data:
+                self.observations_data = data
+                if self.observations_data["data"]["wind"] is not None:
+                    flatten_dict(["wind"], self.observations_data["data"])
+                else:
+                    self.observations_data["data"]["wind_direction"] = "unavailable"
+                    self.observations_data["data"]["wind_speed_kilometre"] = "unavailable"
+                    self.observations_data["data"]["wind_speed_knot"] = "unavailable"
+                if self.observations_data["data"]["gust"] is not None:
+                    flatten_dict(["gust"], self.observations_data["data"])
+                else:
+                    self.observations_data["data"]["gust_speed_kilometre"] = "unavailable"
+                    self.observations_data["data"]["gust_speed_knot"] = "unavailable"
+
+                # Calculate dew point using Magnus-Tetens formula
+                temp = self.observations_data["data"].get("temp")
+                humidity = self.observations_data["data"].get("humidity")
+                if temp is not None and humidity is not None:
+                    try:
+                        # Magnus-Tetens approximation
+                        a = 17.27
+                        b = 237.7
+                        gamma = (a * temp / (b + temp)) + math.log(humidity / 100.0)
+                        dew_point = (b * gamma) / (a - gamma)
+                        self.observations_data["data"]["dew_point"] = round(dew_point, 1)
+                    except (TypeError, ValueError, ZeroDivisionError) as err:
+                        _LOGGER.debug(f"Error calculating dew point: {err}")
                         self.observations_data["data"]["dew_point"] = None
+                else:
+                    self.observations_data["data"]["dew_point"] = None
 
-                    # Calculate Delta-T (temperature - dew point)
-                    temp = self.observations_data["data"].get("temp")
-                    dew_point = self.observations_data["data"].get("dew_point")
-                    if temp is not None and dew_point is not None:
-                        try:
-                            self.observations_data["data"]["delta_t"] = round(temp - dew_point, 1)
-                        except (TypeError, ValueError):
-                            self.observations_data["data"]["delta_t"] = None
-                    else:
+                # Calculate Delta-T (temperature - dew point)
+                temp = self.observations_data["data"].get("temp")
+                dew_point = self.observations_data["data"].get("dew_point")
+                if temp is not None and dew_point is not None:
+                    try:
+                        self.observations_data["data"]["delta_t"] = round(temp - dew_point, 1)
+                    except (TypeError, ValueError):
                         self.observations_data["data"]["delta_t"] = None
+                else:
+                    self.observations_data["data"]["delta_t"] = None
 
-                # Get daily forecast data
-                data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash + URL_DAILY, "daily_forecasts"
-                )
-                if data:
-                    self.daily_forecasts_data = data
-                    await self.format_daily_forecast_data()
+            # Get daily forecast data
+            data = await self._fetch_with_retry(
+                URL_BASE + self.geohash + URL_DAILY, "daily_forecasts"
+            )
+            if data:
+                self.daily_forecasts_data = data
+                await self.format_daily_forecast_data()
 
-                # Get hourly forecast data
-                data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash + URL_HOURLY, "hourly_forecasts"
-                )
-                if data:
-                    self.hourly_forecasts_data = data
-                    await self.format_hourly_forecast_data()
+            # Get hourly forecast data
+            data = await self._fetch_with_retry(
+                URL_BASE + self.geohash + URL_HOURLY, "hourly_forecasts"
+            )
+            if data:
+                self.hourly_forecasts_data = data
+                await self.format_hourly_forecast_data()
 
-                # Get warnings data
-                data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash + URL_WARNINGS, "warnings"
-                )
-                if data:
-                    self.warnings_data = data
-                    
+            # Get warnings data
+            data = await self._fetch_with_retry(
+                URL_BASE + self.geohash + URL_WARNINGS, "warnings"
+            )
+            if data:
+                self.warnings_data = data
+
         except Exception as err:
             _LOGGER.error(f"Unexpected error during async_update: {err}")
             # Even if we have an unexpected error, we still have our cached data

--- a/custom_components/ha_bom_australia/__init__.py
+++ b/custom_components/ha_bom_australia/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Final
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import debounce
 from homeassistant.helpers import device_registry as dr
@@ -69,7 +70,11 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up BOM from a config entry."""
-    collector = Collector(entry.data[CONF_LATITUDE], entry.data[CONF_LONGITUDE])
+    collector = Collector(
+        entry.data[CONF_LATITUDE],
+        entry.data[CONF_LONGITUDE],
+        async_get_clientsession(hass),
+    )
 
     coordinator = BomDataUpdateCoordinator(hass=hass, collector=collector, config_entry=entry)
     await coordinator.async_load_temps()

--- a/custom_components/ha_bom_australia/config_flow.py
+++ b/custom_components/ha_bom_australia/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_ENTITY_PREFIX,
@@ -67,35 +68,34 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if use_postcode:
                     if postcode and postcode.strip():
                         # Query BOM API for locations in this postcode
-                        import aiohttp
                         try:
-                            async with aiohttp.ClientSession() as session:
-                                url = f"https://api.weather.bom.gov.au/v1/locations?search={postcode.strip()}"
-                                headers = {"User-Agent": "MakeThisAPIOpenSource/1.0.0"}
-                                async with session.get(url, headers=headers) as resp:
-                                    if resp.status == 200:
-                                        result = await resp.json()
-                                        locations = result.get("data", [])
+                            session = async_get_clientsession(self.hass)
+                            url = f"https://api.weather.bom.gov.au/v1/locations?search={postcode.strip()}"
+                            headers = {"User-Agent": "MakeThisAPIOpenSource/1.0.0"}
+                            async with session.get(url, headers=headers) as resp:
+                                if resp.status == 200:
+                                    result = await resp.json()
+                                    locations = result.get("data", [])
 
-                                        if not locations:
-                                            _LOGGER.debug(f"No locations found for postcode: {postcode}")
-                                            errors["base"] = "invalid_postcode"
-                                        elif len(locations) == 1:
-                                            # Only one location, use it directly
-                                            location = locations[0]
-                                            self.postcode_location = location
-                                            # Store postcode for later use
-                                            self.postcode = postcode.strip()
-                                            # Move to weather_name step (will extract coords from geohash there)
-                                            return await self.async_step_weather_name()
-                                        else:
-                                            # Multiple locations, let user choose
-                                            self.postcode_locations = locations
-                                            self.postcode = postcode.strip()
-                                            return await self.async_step_select_location()
-                                    else:
-                                        _LOGGER.debug(f"BOM API returned status {resp.status} for postcode: {postcode}")
+                                    if not locations:
+                                        _LOGGER.debug(f"No locations found for postcode: {postcode}")
                                         errors["base"] = "invalid_postcode"
+                                    elif len(locations) == 1:
+                                        # Only one location, use it directly
+                                        location = locations[0]
+                                        self.postcode_location = location
+                                        # Store postcode for later use
+                                        self.postcode = postcode.strip()
+                                        # Move to weather_name step (will extract coords from geohash there)
+                                        return await self.async_step_weather_name()
+                                    else:
+                                        # Multiple locations, let user choose
+                                        self.postcode_locations = locations
+                                        self.postcode = postcode.strip()
+                                        return await self.async_step_select_location()
+                                else:
+                                    _LOGGER.debug(f"BOM API returned status {resp.status} for postcode: {postcode}")
+                                    errors["base"] = "invalid_postcode"
                         except Exception as e:
                             _LOGGER.exception(f"Error querying BOM API for postcode {postcode}: {e}")
                             errors["base"] = "cannot_connect"
@@ -108,6 +108,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self.collector = Collector(
                         float(latitude),
                         float(longitude),
+                        async_get_clientsession(self.hass),
                     )
 
                     # Save the coordinates to data
@@ -194,6 +195,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.collector = Collector(
                 float(latitude),
                 float(longitude),
+                async_get_clientsession(self.hass),
                 geohash=geohash  # Pass BOM's geohash directly
             )
 
@@ -503,33 +505,32 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                 if use_postcode:
                     if postcode and postcode.strip():
                         # Query BOM API for locations in this postcode
-                        import aiohttp
                         try:
-                            async with aiohttp.ClientSession() as session:
-                                url = f"https://api.weather.bom.gov.au/v1/locations?search={postcode.strip()}"
-                                headers = {"User-Agent": "MakeThisAPIOpenSource/1.0.0"}
-                                async with session.get(url, headers=headers) as resp:
-                                    if resp.status == 200:
-                                        result = await resp.json()
-                                        locations = result.get("data", [])
+                            session = async_get_clientsession(self.hass)
+                            url = f"https://api.weather.bom.gov.au/v1/locations?search={postcode.strip()}"
+                            headers = {"User-Agent": "MakeThisAPIOpenSource/1.0.0"}
+                            async with session.get(url, headers=headers) as resp:
+                                if resp.status == 200:
+                                    result = await resp.json()
+                                    locations = result.get("data", [])
 
-                                        if not locations:
-                                            _LOGGER.debug(f"No locations found for postcode: {postcode}")
-                                            errors["base"] = "invalid_postcode"
-                                        elif len(locations) == 1:
-                                            # Only one location, use it directly
-                                            location = locations[0]
-                                            self.postcode_location = location
-                                            self.postcode = postcode.strip()
-                                            return await self.async_step_weather_name()
-                                        else:
-                                            # Multiple locations, let user choose
-                                            self.postcode_locations = locations
-                                            self.postcode = postcode.strip()
-                                            return await self.async_step_select_location()
-                                    else:
-                                        _LOGGER.debug(f"BOM API returned status {resp.status} for postcode: {postcode}")
+                                    if not locations:
+                                        _LOGGER.debug(f"No locations found for postcode: {postcode}")
                                         errors["base"] = "invalid_postcode"
+                                    elif len(locations) == 1:
+                                        # Only one location, use it directly
+                                        location = locations[0]
+                                        self.postcode_location = location
+                                        self.postcode = postcode.strip()
+                                        return await self.async_step_weather_name()
+                                    else:
+                                        # Multiple locations, let user choose
+                                        self.postcode_locations = locations
+                                        self.postcode = postcode.strip()
+                                        return await self.async_step_select_location()
+                                else:
+                                    _LOGGER.debug(f"BOM API returned status {resp.status} for postcode: {postcode}")
+                                    errors["base"] = "invalid_postcode"
                         except Exception as e:
                             _LOGGER.exception(f"Error querying BOM API for postcode {postcode}: {e}")
                             errors["base"] = "cannot_connect"
@@ -542,6 +543,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                     self.collector = Collector(
                         user_input[CONF_LATITUDE],
                         user_input[CONF_LONGITUDE],
+                        async_get_clientsession(self.hass),
                     )
 
                     # Save the user input into self.data so it's retained
@@ -622,6 +624,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
             self.collector = Collector(
                 float(latitude),
                 float(longitude),
+                async_get_clientsession(self.hass),
                 geohash=geohash  # Pass BOM's geohash directly
             )
 


### PR DESCRIPTION
`Collector` created and tore down an `aiohttp.ClientSession` on every call, so each coordinator cycle paid for a new connector, DNS resolution and TLS handshake instead of reusing a pooled connection. The config flow's postcode search did the same.

`Collector` now takes a session it does not own, and all five construction sites pass `async_get_clientsession(hass)`. The `User-Agent` moves from a per-session default to a per-request header, since the shared session must not be mutated.

Note for reviewers: most of the diff is a dedent of `async_update`'s body. The shared session must never be used as an `async with` context manager — that would close a session the rest of Home Assistant is still using — so the wrappers were removed rather than repointed. The logic inside is unchanged apart from indentation and the dropped `session,` argument.