### PR TITLE
chore: drop the nightly cron from the validation workflows

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -3,8 +3,6 @@ name: Hassfest
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,8 +3,6 @@ name: Validate
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Removes the nightly `schedule:` trigger from Hassfest and Validate.

GitHub disables scheduled workflows after a period of repository inactivity, and it disables the whole workflow rather than just the cron — the `push:` and `pull_request:` triggers stop with it. Both checks only carry weight when evaluated against an actual change, so dropping the cron keeps per-push and per-PR coverage from depending on a trigger that can lapse.

`Release` is unaffected; it is `workflow_dispatch` only.