### PR TITLE
chore: drop the iso8601 dependency

### DIFF
--- a/custom_components/ha_bom_australia/PyBoM/helpers.py
+++ b/custom_components/ha_bom_australia/PyBoM/helpers.py
@@ -1,7 +1,18 @@
 """Helpers functions for PyBom."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO 8601 timestamp, defaulting to UTC when no offset is given.
+
+    Raises ValueError if the value is not a valid timestamp.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 def flatten_dict(keys: list[str], dict: dict[str, Any]) -> dict[str, Any]:
     """Flatten nested dictionary keys."""

--- a/custom_components/ha_bom_australia/manifest.json
+++ b/custom_components/ha_bom_australia/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/safepay/ha_bom_australia/issues",
-  "requirements": ["iso8601"],
+  "requirements": [],
   "version": "1.6.4"
 }

--- a/custom_components/ha_bom_australia/sensor.py
+++ b/custom_components/ha_bom_australia/sensor.py
@@ -5,7 +5,6 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Final
 
-import iso8601
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
@@ -49,6 +48,7 @@ from .const import (
     CONDITION_FRIENDLY,
 )
 from .PyBoM.collector import Collector
+from .PyBoM.helpers import parse_iso_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -253,8 +253,8 @@ class ObservationSensor(SensorBase):
         tzinfo = ZoneInfo(self.collector.locations_data["data"]["timezone"])
         for key in self.collector.observations_data["metadata"]:
             try:
-                attr[key] = iso8601.parse_date(self.collector.observations_data["metadata"][key]).astimezone(tzinfo).isoformat()
-            except iso8601.ParseError:
+                attr[key] = parse_iso_datetime(self.collector.observations_data["metadata"][key]).astimezone(tzinfo).isoformat()
+            except ValueError:
                 attr[key] = self.collector.observations_data["metadata"][key]
 
         attr.update(self.collector.observations_data["data"]["station"])
@@ -288,7 +288,7 @@ class ObservationSensor(SensorBase):
             return attr
 
         # We have all required data, now add the time_observed attribute
-        attr["time_observed"] = iso8601.parse_date(time_str).astimezone(tzinfo).isoformat()
+        attr["time_observed"] = parse_iso_datetime(time_str).astimezone(tzinfo).isoformat()
         return attr
 
     @property
@@ -354,11 +354,11 @@ class ForecastSensor(SensorBase):
             tzinfo = ZoneInfo(self.collector.locations_data["data"]["timezone"])
             for key in self.collector.daily_forecasts_data["metadata"]:
                 try:
-                    attr[key] = iso8601.parse_date(self.collector.daily_forecasts_data["metadata"][key]).astimezone(tzinfo).isoformat()
-                except iso8601.ParseError:
+                    attr[key] = parse_iso_datetime(self.collector.daily_forecasts_data["metadata"][key]).astimezone(tzinfo).isoformat()
+                except ValueError:
                     attr[key] = self.collector.daily_forecasts_data["metadata"][key]
             attr[ATTR_ATTRIBUTION] = ATTRIBUTION
-            attr[ATTR_DATE] = iso8601.parse_date(self.collector.daily_forecasts_data["data"][self.day]["date"]).astimezone(tzinfo).isoformat()
+            attr[ATTR_DATE] = parse_iso_datetime(self.collector.daily_forecasts_data["data"][self.day]["date"]).astimezone(tzinfo).isoformat()
             if (self.sensor_name == "fire_danger") and (self.current_state is not None):
                 # Safely get fire_danger_category (may be null after ~4pm, but restored by coordinator)
                 fire_danger_category = self.collector.daily_forecasts_data["data"][self.day].get("fire_danger_category")
@@ -383,8 +383,8 @@ class ForecastSensor(SensorBase):
                     self.collector.locations_data["data"]["timezone"]
                 )
                 try:
-                    return iso8601.parse_date(self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]).astimezone(tzinfo).isoformat()
-                except iso8601.ParseError:
+                    return parse_iso_datetime(self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]).astimezone(tzinfo).isoformat()
+                except ValueError:
                     return self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
             if self.sensor_name == "uv_forecast":
                 if self.collector.daily_forecasts_data["data"][self.day]["uv_category"] is None:

--- a/custom_components/ha_bom_australia/weather.py
+++ b/custom_components/ha_bom_australia/weather.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 
-import iso8601
 from homeassistant.components.weather import Forecast, WeatherEntity, WeatherEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfSpeed, UnitOfTemperature, UnitOfPressure, UnitOfLength
@@ -33,6 +32,7 @@ from .const import (
 )
 from .PyBoM.collector import Collector
 from .PyBoM.const import MAP_MDI_ICON, apply_day_night
+from .PyBoM.helpers import parse_iso_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ class WeatherBase(WeatherEntity):
         tzinfo = ZoneInfo(self.collector.locations_data["data"]["timezone"])
         return [
             Forecast(
-                datetime=iso8601.parse_date(data["date"]).astimezone(tzinfo).replace(tzinfo=None).isoformat(),
+                datetime=parse_iso_datetime(data["date"]).astimezone(tzinfo).replace(tzinfo=None).isoformat(),
                 native_temperature=data.get("temp_max"),
                 condition=MAP_CONDITION.get(data.get("icon_descriptor")),
                 templow=data.get("temp_min"),
@@ -129,7 +129,7 @@ class WeatherBase(WeatherEntity):
         tzinfo = ZoneInfo(self.collector.locations_data["data"]["timezone"])
         return [
             Forecast(
-                datetime=iso8601.parse_date(data["time"]).astimezone(tzinfo).replace(tzinfo=None).isoformat(),
+                datetime=parse_iso_datetime(data["time"]).astimezone(tzinfo).replace(tzinfo=None).isoformat(),
                 native_temperature=data.get("temp"),
                 condition=MAP_CONDITION.get(data.get("icon_descriptor")),
                 native_precipitation=data.get("rain_amount_max"),


### PR DESCRIPTION
Python 3.11 broadened `datetime.fromisoformat` into a general ISO 8601 parser, so the stdlib now covers every timestamp format BOM returns — including the `Z` suffix that originally required `iso8601`. Home Assistant 2024.11 requires Python 3.12, so this needs nothing newer than the declared minimum.

Adds `parse_iso_datetime` to `PyBoM.helpers`, which keeps two behaviours the old call sites relied on:

- assumes UTC when a timestamp carries no offset, as `iso8601.parse_date` did (without this, `.astimezone()` on a naive value would silently assume system-local time)
- raises `ValueError` in place of `ParseError`, so the three fallback-to-raw-value paths in `sensor.py` still apply

The helper is stdlib-only, keeping `PyBoM` free of Home Assistant imports. `requirements` in the manifest becomes empty, so the integration now installs with no third-party packages.

Verified `fromisoformat` against the formats BOM emits (`Z`-suffixed, explicit offset, fractional seconds, naive) and confirmed non-timestamp input still raises.