### PR TITLE
fix: make homeassistant.update_entity work on BOM entities

### DIFF
--- a/custom_components/ha_bom_australia/sensor.py
+++ b/custom_components/ha_bom_australia/sensor.py
@@ -215,10 +215,6 @@ class SensorBase(CoordinatorEntity[BomDataUpdateCoordinator], SensorEntity):
         """Entities do not individually poll."""
         return False
 
-    async def async_update(self) -> None:
-        """Refresh the data on the collector object."""
-        await self.collector.async_update()
-
 
 class ObservationSensor(SensorBase):
     """Representation of a BOM Observation Sensor."""

--- a/custom_components/ha_bom_australia/weather.py
+++ b/custom_components/ha_bom_australia/weather.py
@@ -257,7 +257,7 @@ class WeatherBase(WeatherEntity):
 
     async def async_update(self) -> None:
         """Update the weather data."""
-        await self.coordinator.async_update()
+        await self.coordinator.async_request_refresh()
 
 
 class BomWeather(WeatherBase):


### PR DESCRIPTION
`async_update` is called by the generic `homeassistant.update_entity` service regardless of `should_poll` — core's `CoordinatorEntity.async_update` docstring says as much ("Only used by the generic entity update service"). Both implementations here were therefore reachable.

**Weather entity:** awaited `self.coordinator.async_update()`, which `DataUpdateCoordinator` does not define, so calling `update_entity` on the weather entity raised `AttributeError`. Now requests a coordinator refresh.

**SensorBase:** overrode `CoordinatorEntity.async_update` with a direct `collector.async_update()` call. That refreshed the collector but bypassed the coordinator's debouncer and left every other entity unaware new data had arrived, so a manual update refreshed one sensor's data while the rest kept serving stale values until the next scheduled poll. Removing the override restores the inherited implementation, which requests a debounced refresh and notifies all listeners.