### PR TITLE
chore: remove shadowed native_value properties

### DIFF
--- a/custom_components/ha_bom_australia/sensor.py
+++ b/custom_components/ha_bom_australia/sensor.py
@@ -233,14 +233,6 @@ class ObservationSensor(SensorBase):
         return f"{self.entity_prefix}_{self.sensor_name}"
 
     @property
-    def native_value(self) -> Any:
-        """Return the state of the device."""
-        # For condition sensor, use the computed state value
-        if self.sensor_name == ATTR_API_CONDITION:
-            return self.state
-        return self.coordinator.data.get(self.entity_description.key)
-
-    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
         attr = {}
@@ -333,11 +325,6 @@ class ForecastSensor(SensorBase):
     def unique_id(self) -> str:
         """Return Unique ID string."""
         return f"{self.entity_prefix}_{self.day}_{self.sensor_name}"
-
-    @property
-    def native_value(self) -> Any:
-        """Return the state of the device."""
-        return self.coordinator.data.get(self.entity_description.key)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -440,11 +427,6 @@ class NowLaterSensor(SensorBase):
         return f"{self.entity_prefix}_{self.sensor_name}"
 
     @property
-    def native_value(self) -> Any:
-        """Return the state of the device."""
-        return self.coordinator.data.get(self.entity_description.key)
-
-    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
         if not self.collector.daily_forecasts_data or "metadata" not in self.collector.daily_forecasts_data:
@@ -487,11 +469,6 @@ class WarningsSensor(SensorBase):
     def unique_id(self) -> str:
         """Return Unique ID string."""
         return f"{self.entity_prefix}_warnings"
-
-    @property
-    def native_value(self) -> Any:
-        """Return the state of the device."""
-        return self.state
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
`ObservationSensor`, `ForecastSensor`, `NowLaterSensor` and `WarningsSensor` each override `state`, and `SensorEntity.state` is the only caller of `native_value`, so all four `native_value` properties were unreachable.

Three of them read `self.coordinator.data.get(...)`, which would have raised `AttributeError` if ever reached — the coordinator's update method has no `return`, so `coordinator.data` is always `None`. The collector holds the data and entities read from it directly, so that is consistent with how the coordinator is used here; removing these properties simply leaves no reader of `coordinator.data` at all.

Each class keeps its `state`, `unique_id`, `extra_state_attributes` and `name` properties, so entity behaviour is unchanged.

Worth noting for later: overriding `state` on a `SensorEntity` bypasses unit conversion, `suggested_display_precision` and timestamp validation. Moving to `native_value` properly is a separate change, since `ForecastSensor` returns ISO strings for `TIMESTAMP` device-class sensors where `native_value` would need a `datetime`.