### PR TITLE
fix: null guards, collector cache replay, and sensor cleanups

### DIFF
--- a/custom_components/ha_bom_australia/PyBoM/collector.py
+++ b/custom_components/ha_bom_australia/PyBoM/collector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import aiohttp
 import asyncio
+import copy
 import logging
 import math
 import time
@@ -85,8 +86,12 @@ class Collector:
                 async with self._session.get(url, headers=HEADERS) as response:
                     if response.status == 200:
                         data = await response.json()
-                        # Update cache with new data and timestamp
-                        self._cache[cache_key]["data"] = data
+                        # Cache a pristine copy, not the object we hand back.
+                        # Callers reshape the response in place (flatten_dict
+                        # pops "rain", "uv" and friends), so sharing one object
+                        # would leave the cache already flattened and make a
+                        # later replay raise KeyError in the formatters.
+                        self._cache[cache_key]["data"] = copy.deepcopy(data)
                         self._cache[cache_key]["timestamp"] = time.time()
                         return data
                     else:
@@ -113,7 +118,10 @@ class Collector:
                         _LOGGER.info(
                             f"Returning cached {cache_key} data from {int(cache_age/60)} minutes ago"
                         )
-                        return cached
+                        # Copy on the way out too, so the caller's in-place
+                        # reshaping does not corrupt the cache for the next
+                        # replay.
+                        return copy.deepcopy(cached)
                     else:
                         _LOGGER.error(f"No cached {cache_key} data available")
                         return None

--- a/custom_components/ha_bom_australia/PyBoM/helpers.py
+++ b/custom_components/ha_bom_australia/PyBoM/helpers.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-def parse_iso_datetime(value: str) -> datetime:
+def parse_iso_datetime(value: Any) -> datetime:
     """Parse an ISO 8601 timestamp, defaulting to UTC when no offset is given.
 
-    Raises ValueError if the value is not a valid timestamp.
+    Raises ValueError if the value is not a valid timestamp, including when it
+    is not a string at all. BOM omits timestamp fields routinely, so callers
+    guarding with `except ValueError` need a null to land there too rather than
+    escaping as the TypeError datetime.fromisoformat would raise.
     """
+    if not isinstance(value, str):
+        raise ValueError(f"not a timestamp string: {value!r}")
     parsed = datetime.fromisoformat(value)
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)

--- a/custom_components/ha_bom_australia/sensor.py
+++ b/custom_components/ha_bom_australia/sensor.py
@@ -503,15 +503,17 @@ class WarningsSensor(SensorBase):
         return attr
 
     @property
-    def state(self) -> Any:
-        """Return the state of the sensor (count of active warnings)."""
-        if (
-            self.collector.warnings_data
-            and "data" in self.collector.warnings_data
-        ):
-            # Return the count of warnings
-            return len(self.collector.warnings_data["data"])
-        return 0
+    def state(self) -> int:
+        """Return the state of the sensor (count of active warnings).
+
+        Reports 0 rather than None when there is no warnings data, so the state
+        stays numeric for template arithmetic and history graphs. A BOM outage
+        is therefore indistinguishable from a quiet day.
+        """
+        if not self.collector.warnings_data:
+            return 0
+        # BOM can send "data": null, which len() cannot take.
+        return len(self.collector.warnings_data.get("data") or [])
 
     @property
     def name(self) -> str:

--- a/custom_components/ha_bom_australia/sensor.py
+++ b/custom_components/ha_bom_australia/sensor.py
@@ -2,20 +2,22 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Final
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.const import (
-    ATTR_ATTRIBUTION,
     ATTR_DATE,
     ATTR_STATE,
 )
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from zoneinfo import ZoneInfo
@@ -44,8 +46,6 @@ from .const import (
     ATTR_API_CONDITION,
     ATTR_API_EXTENDED_TEXT,
     ATTR_API_FIRE_DANGER,
-    MAP_CONDITION,
-    CONDITION_FRIENDLY,
 )
 from .PyBoM.collector import Collector
 from .PyBoM.helpers import parse_iso_datetime
@@ -189,11 +189,12 @@ async def async_setup_entry(
 class SensorBase(CoordinatorEntity[BomDataUpdateCoordinator], SensorEntity):
     """Base representation of a BOM Sensor."""
 
+    _attr_attribution = ATTRIBUTION
+
     def __init__(self, hass_data, location_name, entity_prefix, sensor_name, description: SensorEntityDescription, device_type: str = "Sensors") -> None:
         """Initialize the sensor."""
         super().__init__(hass_data[COORDINATOR])
         self.collector: Collector = hass_data[COLLECTOR]
-        self.coordinator: BomDataUpdateCoordinator = hass_data[COORDINATOR]
         self.location_name: str = location_name
         self.entity_prefix: str = entity_prefix
         self.sensor_name: str = sensor_name
@@ -210,20 +211,6 @@ class SensorBase(CoordinatorEntity[BomDataUpdateCoordinator], SensorEntity):
             model=MODEL_NAME,
             name=f"BOM {self.location_name} {device_type}",
         )
-
-    async def async_added_to_hass(self) -> None:
-        """Set up a listener and load data."""
-        self.async_on_remove(self.coordinator.async_add_listener(self._update_callback))
-        self._update_callback()
-
-    @callback
-    def _update_callback(self) -> None:
-        self.async_write_ha_state()
-
-    @property
-    def should_poll(self) -> bool:
-        """Entities do not individually poll."""
-        return False
 
 
 class ObservationSensor(SensorBase):
@@ -244,9 +231,9 @@ class ObservationSensor(SensorBase):
         attr = {}
 
         if not self.collector.locations_data or "data" not in self.collector.locations_data:
-            return {ATTR_ATTRIBUTION: ATTRIBUTION}
+            return attr
         if not self.collector.observations_data or "metadata" not in self.collector.observations_data:
-            return {ATTR_ATTRIBUTION: ATTRIBUTION}
+            return attr
 
         tzinfo = ZoneInfo(self.collector.locations_data["data"]["timezone"])
         for key in self.collector.observations_data["metadata"]:
@@ -256,7 +243,6 @@ class ObservationSensor(SensorBase):
                 attr[key] = self.collector.observations_data["metadata"][key]
 
         attr.update(self.collector.observations_data["data"]["station"])
-        attr[ATTR_ATTRIBUTION] = ATTRIBUTION
 
         # Add extended forecast text for condition sensor
         if self.sensor_name == ATTR_API_CONDITION:
@@ -350,7 +336,6 @@ class ForecastSensor(SensorBase):
                     attr[key] = parse_iso_datetime(self.collector.daily_forecasts_data["metadata"][key]).astimezone(tzinfo).isoformat()
                 except ValueError:
                     attr[key] = self.collector.daily_forecasts_data["metadata"][key]
-            attr[ATTR_ATTRIBUTION] = ATTRIBUTION
             attr[ATTR_DATE] = parse_iso_datetime(self.collector.daily_forecasts_data["data"][self.day]["date"]).astimezone(tzinfo).isoformat()
             if (self.sensor_name == "fire_danger") and (self.current_state is not None):
                 # Safely get fire_danger_category (may be null after ~4pm, but restored by coordinator)
@@ -442,10 +427,8 @@ class NowLaterSensor(SensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
         if not self.collector.daily_forecasts_data or "metadata" not in self.collector.daily_forecasts_data:
-            return {ATTR_ATTRIBUTION: ATTRIBUTION}
-        attr = dict(self.collector.daily_forecasts_data["metadata"])
-        attr[ATTR_ATTRIBUTION] = ATTRIBUTION
-        return attr
+            return {}
+        return dict(self.collector.daily_forecasts_data["metadata"])
 
     @property
     def state(self) -> Any:
@@ -499,7 +482,6 @@ class WarningsSensor(SensorBase):
             if "metadata" in self.collector.warnings_data:
                 attr["response_timestamp"] = self.collector.warnings_data["metadata"].get("response_timestamp")
 
-        attr[ATTR_ATTRIBUTION] = ATTRIBUTION
         return attr
 
     @property

--- a/custom_components/ha_bom_australia/sensor.py
+++ b/custom_components/ha_bom_australia/sensor.py
@@ -55,6 +55,16 @@ _LOGGER = logging.getLogger(__name__)
 MAX_STATE_LENGTH: Final[int] = 251  # Maximum length for sensor state before truncation
 
 
+def format_short_time(value: datetime) -> str:
+    """Format a time as e.g. '6:12am'.
+
+    Avoids strftime's "%-I" hour padding modifier, which is a glibc extension
+    and raises ValueError on Windows, and its locale-dependent "%p".
+    """
+    meridiem = "am" if value.hour < 12 else "pm"
+    return f"{value.hour % 12 or 12}:{value.minute:02d}{meridiem}"
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -370,25 +380,31 @@ class ForecastSensor(SensorBase):
                 except ValueError:
                     return self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
             if self.sensor_name == "uv_forecast":
-                if self.collector.daily_forecasts_data["data"][self.day]["uv_category"] is None:
+                day_data = self.collector.daily_forecasts_data["data"][self.day]
+                uv_category = day_data.get("uv_category")
+                if uv_category is None:
                     return None
-                if self.collector.daily_forecasts_data["data"][self.day]["uv_start_time"] is None:
-                    return (
-                        f"Sun protection not required, UV Index predicted to reach "
-                        f'{self.collector.daily_forecasts_data["data"][self.day]["uv_max_index"]} '
-                        f'[{self.collector.daily_forecasts_data["data"][self.day]["uv_category"].replace("veryhigh", "very high").title()}]'
-                    )
-                else:
-                    utc = timezone.utc
-                    local = ZoneInfo(self.collector.locations_data["data"]["timezone"])
-                    start_time = datetime.strptime(self.collector.daily_forecasts_data["data"][self.day]["uv_start_time"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=utc).astimezone(local)
-                    end_time = datetime.strptime(self.collector.daily_forecasts_data["data"][self.day]["uv_end_time"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=utc).astimezone(local)
-                    return (
-                        f'Sun protection recommended from {start_time.strftime("%-I:%M%p").lower()} to '
-                        f'{end_time.strftime("%-I:%M%p").lower()}, UV Index predicted to reach '
-                        f'{self.collector.daily_forecasts_data["data"][self.day]["uv_max_index"]} '
-                        f'[{self.collector.daily_forecasts_data["data"][self.day]["uv_category"].replace("veryhigh", "very high").title()}]'
-                    )
+                category = uv_category.replace("veryhigh", "very high").title()
+                max_index = day_data.get("uv_max_index")
+                no_protection_required = (
+                    f"Sun protection not required, UV Index predicted to reach "
+                    f"{max_index} [{category}]"
+                )
+
+                # BOM omits both UV times overnight and outside the UV season,
+                # and has been seen returning one of the pair without the other.
+                local = ZoneInfo(self.collector.locations_data["data"]["timezone"])
+                try:
+                    start_time = parse_iso_datetime(day_data.get("uv_start_time")).astimezone(local)
+                    end_time = parse_iso_datetime(day_data.get("uv_end_time")).astimezone(local)
+                except ValueError:
+                    return no_protection_required
+
+                return (
+                    f"Sun protection recommended from {format_short_time(start_time)} to "
+                    f"{format_short_time(end_time)}, UV Index predicted to reach "
+                    f"{max_index} [{category}]"
+                )
             new_state = self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
 
             if isinstance(new_state, str) and len(new_state) > MAX_STATE_LENGTH:


### PR DESCRIPTION
Groundwork before moving the sensors from `state` to `native_value`. All six
changes here are independent of that migration and none of them touch the
value getters' structure, so they can land on their own.

Five commits, each self-contained. No version bump — `manifest.json` is
untouched.

## Fixes

**`parse_iso_datetime` raised `TypeError` where callers guarded `ValueError`**
(`9c69ce6`). The helper's docstring promised `ValueError` and all three call
sites were written against that promise, but it dated from the old
`iso8601.ParseError` API, which was a `ValueError` subclass and covered `None`.
`datetime.fromisoformat` raises `TypeError` on a non-str instead, so the guards
silently stopped catching the most common case. BOM omits timestamps routinely —
`uv_start_time` and `uv_end_time` are null overnight and through winter — so
this escaped as an unhandled `TypeError` out of `ObservationSensor` and
`ForecastSensor`.

**The collector cache could not actually be replayed** (`b97bcb9`).
`_fetch_with_retry` stored the same dict object it returned, and the callers
reshape that object in place — `flatten_dict` pops `wind`, `gust`, `rain`, `uv`
and `astronomical` rather than copying. The cache therefore held
already-flattened data, and replaying it after a BOM outage subscripted keys
that were gone.

The first failure is `observations_data["data"]["wind"]`, because observations
are fetched first. `async_update` wraps its body in `except Exception`, so this
was logged rather than raised — but it aborted the remaining fetches. Endpoints
attempted on a cache replay:

```
before:  ['observations']
after:   ['observations', 'daily', 'hourly', 'warnings']
```

So during an outage the daily, hourly and warnings caches were never replayed.
Those entities kept their last values and went quietly stale instead of
unavailable, which is harder to notice, and the warnings sensor was among them.
Fixed by deep-copying on both store and return; copying only on store still
hands the pristine object out to be mutated on the first replay.

**`uv_end_time` was never null-checked, and `%-I` is glibc-only** (`3568d3d`).
Only `uv_start_time` was guarded, so a forecast carrying one time without the
other reached `strptime` with `None`. Both now go through `parse_iso_datetime`,
which also removes a hardcoded `Z` and a second timestamp format that could
break independently of the shared helper. Separately, `%-I` is a glibc strftime
padding extension and raises `ValueError: Invalid format string` elsewhere, so
this sensor was broken for anyone running HA Core in a venv on Windows.
Replaced with a small `format_short_time`, which also drops the
locale-dependent `%p`.

**The warnings count could be handed `None`** (`ed5c8a3`). The check was
`"data" in warnings_data`, which passes when BOM sends `"data": null` and then
calls `len(None)`. It still reports `0` when there is no warnings data at all —
that conflates an outage with a quiet day, but it keeps the state numeric so
template arithmetic and history graphs never see `unknown`. The trade-off is
now stated in the docstring.

## Cleanup

`fc0260f`, no behaviour change. `SensorBase` re-implemented three things
`BaseCoordinatorEntity` already provides (`should_poll`, `async_added_to_hass`,
and a `self.coordinator` assignment `CoordinatorEntity.__init__` had just made
with the same object). The `async_added_to_hass` override also skipped its own
`super()` call.

Seven hand-rolled `attr[ATTR_ATTRIBUTION]` assignments collapse to one
`_attr_attribution` on the base class. HA applies it *after* merging
`extra_state_attributes`, so attribution now also survives the early-return
paths in `ForecastSensor` and `ObservationSensor` that previously dropped it.

Also drops four imports that appeared only on their import lines, plus three
more the changes above made dead.

## Verification

There is no test suite, so each change was checked directly:

- The cache-replay `KeyError` was reproduced against `HEAD` with a fake session
  (first fetch succeeds, subsequent fetches raise) and confirmed gone after the
  fix, including across two consecutive replays.
- `format_short_time` was compared against glibc's `"%-I:%M%p".lower()` output
  for all 24 hours x 4 minutes — identical throughout, including the `12:05am`
  and `12:00pm` wraparounds.
- `parse_iso_datetime` was checked to raise `ValueError` for `None`, `123` and
  `{}` while still parsing real values and a trailing `Z`.
- `should_poll` still resolves to `False` after removing the override —
  `BaseCoordinatorEntity` precedes `SensorEntity` in the MRO. This was the one
  removal that could have silently started polling all 37 sensors.
- `sensor.py`, `helpers.py` and `collector.py` are ruff-clean; the whole
  integration compiles.

## Not in scope

- The `state` -> `native_value` migration itself.
- The warnings count does not filter `phase == "cancelled"`, unlike
  `BomWarningSensor._is_inactive_phase`, so it can read `1` while every warning
  binary sensor reads off.
- `BomWarningSensor.is_on` has the same no-data conflation on a `SAFETY` device
  class.
- `binary_sensor.py` carries a similar-looking override trio, but
  `BomWarningSensor` extends `BinarySensorEntity` directly, so there is no base
  implementation to inherit and removing them would be a behaviour change.
- Eleven pre-existing ruff findings in `config_flow.py`, `const.py` and
  `weather.py`.
