### PR TITLE
chore: report sensor values through native_value

### DIFF
--- a/custom_components/ha_bom_australia/PyBoM/collector.py
+++ b/custom_components/ha_bom_australia/PyBoM/collector.py
@@ -219,14 +219,17 @@ class Collector:
                 if self.observations_data["data"]["wind"] is not None:
                     flatten_dict(["wind"], self.observations_data["data"])
                 else:
+                    # The speeds must stay None rather than a placeholder string:
+                    # they are numeric sensors, and the sensor platform rejects a
+                    # non-numeric value for one with a unit and a device class.
                     self.observations_data["data"]["wind_direction"] = "unavailable"
-                    self.observations_data["data"]["wind_speed_kilometre"] = "unavailable"
-                    self.observations_data["data"]["wind_speed_knot"] = "unavailable"
+                    self.observations_data["data"]["wind_speed_kilometre"] = None
+                    self.observations_data["data"]["wind_speed_knot"] = None
                 if self.observations_data["data"]["gust"] is not None:
                     flatten_dict(["gust"], self.observations_data["data"])
                 else:
-                    self.observations_data["data"]["gust_speed_kilometre"] = "unavailable"
-                    self.observations_data["data"]["gust_speed_knot"] = "unavailable"
+                    self.observations_data["data"]["gust_speed_kilometre"] = None
+                    self.observations_data["data"]["gust_speed_knot"] = None
 
                 # Calculate dew point using Magnus-Tetens formula
                 temp = self.observations_data["data"].get("temp")

--- a/custom_components/ha_bom_australia/sensor.py
+++ b/custom_components/ha_bom_australia/sensor.py
@@ -198,7 +198,6 @@ class SensorBase(CoordinatorEntity[BomDataUpdateCoordinator], SensorEntity):
         self.location_name: str = location_name
         self.entity_prefix: str = entity_prefix
         self.sensor_name: str = sensor_name
-        self.current_state: Any = None
         self.entity_description = description
 
         # Determine device identifier suffix based on device type
@@ -211,6 +210,12 @@ class SensorBase(CoordinatorEntity[BomDataUpdateCoordinator], SensorEntity):
             model=MODEL_NAME,
             name=f"BOM {self.location_name} {device_type}",
         )
+
+    def _timezone(self) -> ZoneInfo | None:
+        """Return the BOM location's timezone, or None when it is unavailable."""
+        location = (self.collector.locations_data or {}).get("data") or {}
+        timezone = location.get("timezone")
+        return ZoneInfo(timezone) if timezone else None
 
 
 class ObservationSensor(SensorBase):
@@ -225,48 +230,55 @@ class ObservationSensor(SensorBase):
         """Return Unique ID string."""
         return f"{self.entity_prefix}_{self.sensor_name}"
 
+    def _observations(self) -> dict[str, Any]:
+        """Return the observations payload, or an empty dict when unavailable."""
+        data = (self.collector.observations_data or {}).get("data")
+        return data if isinstance(data, dict) else {}
+
+    def _today_forecast(self) -> dict[str, Any]:
+        """Return today's daily forecast, or an empty dict when unavailable."""
+        data = (self.collector.daily_forecasts_data or {}).get("data")
+        if not data:
+            return {}
+        return data[0] if isinstance(data[0], dict) else {}
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
-        attr = {}
+        attr: dict[str, Any] = {}
 
-        if not self.collector.locations_data or "data" not in self.collector.locations_data:
-            return attr
-        if not self.collector.observations_data or "metadata" not in self.collector.observations_data:
+        tzinfo = self._timezone()
+        if tzinfo is None:
             return attr
 
-        tzinfo = ZoneInfo(self.collector.locations_data["data"]["timezone"])
-        for key in self.collector.observations_data["metadata"]:
+        # BOM can send "metadata": null, which is not iterable.
+        metadata = (self.collector.observations_data or {}).get("metadata")
+        if metadata is None:
+            return attr
+
+        for key, value in metadata.items():
             try:
-                attr[key] = parse_iso_datetime(self.collector.observations_data["metadata"][key]).astimezone(tzinfo).isoformat()
+                attr[key] = parse_iso_datetime(value).astimezone(tzinfo).isoformat()
             except ValueError:
-                attr[key] = self.collector.observations_data["metadata"][key]
+                attr[key] = value
 
-        attr.update(self.collector.observations_data["data"]["station"])
+        attr.update(self._observations().get("station") or {})
 
         # Add extended forecast text for condition sensor
         if self.sensor_name == ATTR_API_CONDITION:
-            if self.collector.daily_forecasts_data and "data" in self.collector.daily_forecasts_data:
-                if len(self.collector.daily_forecasts_data["data"]) > 0:
-                    extended_text = self.collector.daily_forecasts_data["data"][0].get("extended_text")
-                    if extended_text:
-                        attr["forecast_text"] = extended_text
+            extended_text = self._today_forecast().get("extended_text")
+            if extended_text:
+                attr["forecast_text"] = extended_text
 
         # Only proceed for max_temp or min_temp
         if self.sensor_name not in ("max_temp", "min_temp"):
             return attr
-    
-        # Get data safely
-        data = self.collector.observations_data.get("data")
-        if not data:
+
+        # These arrive as {"value": ..., "time": ...} rather than a bare number.
+        sensor_data = self._observations().get(self.sensor_name)
+        if not isinstance(sensor_data, dict):
             return attr
-    
-        # Get sensor data safely
-        sensor_data = data.get(self.sensor_name)
-        if not sensor_data:
-            return attr
-    
-        # Get time safely
+
         time_str = sensor_data.get("time")
         if not time_str:
             return attr
@@ -276,28 +288,24 @@ class ObservationSensor(SensorBase):
         return attr
 
     @property
-    def state(self) -> Any:
-        """Return the state of the sensor."""
-        # Special handling for condition sensor - use short_text from daily forecast
+    def native_value(self) -> Any:
+        """Return the value reported by the sensor."""
+        # The condition sensor has no observation of its own: it reports the
+        # daily forecast's short_text.
         if self.sensor_name == ATTR_API_CONDITION:
-            if self.collector.daily_forecasts_data and "data" in self.collector.daily_forecasts_data:
-                if len(self.collector.daily_forecasts_data["data"]) > 0:
-                    short_text = self.collector.daily_forecasts_data["data"][0].get("short_text")
-                    if short_text:
-                        # Remove trailing punctuation for cleaner display
-                        return short_text.rstrip(".!,;:")
-            return None
+            short_text = self._today_forecast().get("short_text")
+            if not short_text:
+                return None
+            # Remove trailing punctuation for cleaner display
+            return short_text.rstrip(".!,;:")
 
-        # Standard observation sensor handling
-        if not self.collector.observations_data or "data" not in self.collector.observations_data:
+        value = self._observations().get(self.sensor_name)
+        if value is None:
             return None
-        if self.sensor_name in self.collector.observations_data["data"]:
-            if self.collector.observations_data["data"][self.sensor_name] is not None:
-                if self.sensor_name == "max_temp" or self.sensor_name == "min_temp":
-                    return self.collector.observations_data["data"][self.sensor_name]["value"]
-                else:
-                    return self.collector.observations_data["data"][self.sensor_name]
-        return None
+        if self.sensor_name in ("max_temp", "min_temp"):
+            # These arrive as {"value": ..., "time": ...} rather than a bare number.
+            return value.get("value") if isinstance(value, dict) else None
+        return value
 
     @property
     def name(self) -> str:
@@ -318,92 +326,128 @@ class ForecastSensor(SensorBase):
         """Return Unique ID string."""
         return f"{self.entity_prefix}_{self.day}_{self.sensor_name}"
 
+    def _day_forecast(self) -> dict[str, Any] | None:
+        """Return this sensor's day of the daily forecast, or None when absent."""
+        data = (self.collector.daily_forecasts_data or {}).get("data")
+        if not data or self.day >= len(data):
+            return None
+        return data[self.day] if isinstance(data[self.day], dict) else None
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the sensor."""
-        attr = {}
-
-        if not self.collector.daily_forecasts_data or "data" not in self.collector.daily_forecasts_data:
-            return attr
-        if not self.collector.locations_data or "data" not in self.collector.locations_data:
-            return attr
+        attr: dict[str, Any] = {}
 
         # If there is no data for this day, do not add attributes for this day.
-        if self.day < len(self.collector.daily_forecasts_data["data"]):
-            tzinfo = ZoneInfo(self.collector.locations_data["data"]["timezone"])
-            for key in self.collector.daily_forecasts_data["metadata"]:
-                try:
-                    attr[key] = parse_iso_datetime(self.collector.daily_forecasts_data["metadata"][key]).astimezone(tzinfo).isoformat()
-                except ValueError:
-                    attr[key] = self.collector.daily_forecasts_data["metadata"][key]
-            attr[ATTR_DATE] = parse_iso_datetime(self.collector.daily_forecasts_data["data"][self.day]["date"]).astimezone(tzinfo).isoformat()
-            if (self.sensor_name == "fire_danger") and (self.current_state is not None):
-                # Safely get fire_danger_category (may be null after ~4pm, but restored by coordinator)
-                fire_danger_category = self.collector.daily_forecasts_data["data"][self.day].get("fire_danger_category")
-                if fire_danger_category and fire_danger_category.get("default_colour"):
-                    attr["color_fill"] = fire_danger_category["default_colour"]
-                    attr["color_text"] = "#ffffff" if (fire_danger_category.get("text") == "Catastrophic") else "#000000"
-            if self.sensor_name.startswith("extended"):
-                attr[ATTR_STATE] = self.collector.daily_forecasts_data["data"][self.day]["extended_text"]
+        day_data = self._day_forecast()
+        if day_data is None:
+            return attr
+        tzinfo = self._timezone()
+        if tzinfo is None:
+            return attr
+
+        # BOM can send "metadata": null, which is not iterable.
+        metadata = (self.collector.daily_forecasts_data or {}).get("metadata") or {}
+        for key, value in metadata.items():
+            try:
+                attr[key] = parse_iso_datetime(value).astimezone(tzinfo).isoformat()
+            except ValueError:
+                attr[key] = value
+
+        date = day_data.get("date")
+        try:
+            attr[ATTR_DATE] = parse_iso_datetime(date).astimezone(tzinfo).isoformat()
+        except ValueError:
+            attr[ATTR_DATE] = date
+
+        if self.sensor_name == "fire_danger" and day_data.get("fire_danger") is not None:
+            # Safely get fire_danger_category (may be null after ~4pm, but restored by coordinator)
+            fire_danger_category = day_data.get("fire_danger_category")
+            if fire_danger_category and fire_danger_category.get("default_colour"):
+                attr["color_fill"] = fire_danger_category["default_colour"]
+                attr["color_text"] = "#ffffff" if (fire_danger_category.get("text") == "Catastrophic") else "#000000"
+        if self.sensor_name.startswith("extended"):
+            attr[ATTR_STATE] = day_data.get("extended_text")
         return attr
+
+    def _uv_forecast(self, day_data: dict[str, Any]) -> str | None:
+        """Build the UV protection summary string."""
+        uv_category = day_data.get("uv_category")
+        if uv_category is None:
+            return None
+        category = uv_category.replace("veryhigh", "very high").title()
+        max_index = day_data.get("uv_max_index")
+        no_protection_required = (
+            f"Sun protection not required, UV Index predicted to reach "
+            f"{max_index} [{category}]"
+        )
+
+        local = self._timezone()
+        if local is None:
+            return no_protection_required
+
+        # BOM omits both UV times overnight and outside the UV season, and has
+        # been seen returning one of the pair without the other.
+        try:
+            start_time = parse_iso_datetime(day_data.get("uv_start_time")).astimezone(local)
+            end_time = parse_iso_datetime(day_data.get("uv_end_time")).astimezone(local)
+        except ValueError:
+            return no_protection_required
+
+        return (
+            f"Sun protection recommended from {format_short_time(start_time)} to "
+            f"{format_short_time(end_time)}, UV Index predicted to reach "
+            f"{max_index} [{category}]"
+        )
 
     @property
     def state(self) -> Any:
-        """Return the state of the sensor."""
-        if not self.collector.daily_forecasts_data or "data" not in self.collector.daily_forecasts_data:
-            return None
-        if not self.collector.locations_data or "data" not in self.collector.locations_data:
-            return None
-        # If there is no data for this day, return state as 'None'.
-        if self.day < len(self.collector.daily_forecasts_data["data"]):
-            if self.device_class == SensorDeviceClass.TIMESTAMP:
-                tzinfo = ZoneInfo(
-                    self.collector.locations_data["data"]["timezone"]
-                )
-                try:
-                    return parse_iso_datetime(self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]).astimezone(tzinfo).isoformat()
-                except ValueError:
-                    return self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
-            if self.sensor_name == "uv_forecast":
-                day_data = self.collector.daily_forecasts_data["data"][self.day]
-                uv_category = day_data.get("uv_category")
-                if uv_category is None:
-                    return None
-                category = uv_category.replace("veryhigh", "very high").title()
-                max_index = day_data.get("uv_max_index")
-                no_protection_required = (
-                    f"Sun protection not required, UV Index predicted to reach "
-                    f"{max_index} [{category}]"
-                )
+        """Return the state of the sensor.
 
-                # BOM omits both UV times overnight and outside the UV season,
-                # and has been seen returning one of the pair without the other.
-                local = ZoneInfo(self.collector.locations_data["data"]["timezone"])
-                try:
-                    start_time = parse_iso_datetime(day_data.get("uv_start_time")).astimezone(local)
-                    end_time = parse_iso_datetime(day_data.get("uv_end_time")).astimezone(local)
-                except ValueError:
-                    return no_protection_required
+        Only the TIMESTAMP sensors are served here; everything else delegates to
+        SensorEntity.state, which reads native_value. Those four still report an
+        ISO 8601 string in the location's local time. Returning a datetime from
+        native_value instead — what a TIMESTAMP sensor is documented to do —
+        makes Home Assistant re-render the state in UTC, which breaks templates
+        that compare or slice the string, so it is held for a release of its own.
+        """
+        if self.device_class != SensorDeviceClass.TIMESTAMP:
+            return super().state
 
-                return (
-                    f"Sun protection recommended from {format_short_time(start_time)} to "
-                    f"{format_short_time(end_time)}, UV Index predicted to reach "
-                    f"{max_index} [{category}]"
-                )
-            new_state = self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
-
-            if isinstance(new_state, str) and len(new_state) > MAX_STATE_LENGTH:
-                self.current_state = new_state[:MAX_STATE_LENGTH] + "..."
-            else:
-                self.current_state = new_state
-            if (self.sensor_name == "uv_category") and (self.current_state is not None):
-                self.current_state = self.current_state.replace("veryhigh", "very high").title()
-            # Strip trailing period from short_text for cleaner display
-            if (self.sensor_name == "short_text") and isinstance(self.current_state, str) and self.current_state.endswith("."):
-                self.current_state = self.current_state.rstrip(".")
-            return self.current_state
-        else:
+        day_data = self._day_forecast()
+        if day_data is None:
             return None
+        value = day_data.get(self.sensor_name)
+        tzinfo = self._timezone()
+        if tzinfo is None:
+            return value
+        try:
+            return parse_iso_datetime(value).astimezone(tzinfo).isoformat()
+        except ValueError:
+            return value
+
+    @property
+    def native_value(self) -> Any:
+        """Return the value reported by the sensor."""
+        # If there is no data for this day, report no value for this day.
+        day_data = self._day_forecast()
+        if day_data is None:
+            return None
+
+        if self.sensor_name == "uv_forecast":
+            return self._uv_forecast(day_data)
+
+        value = day_data.get(self.sensor_name)
+
+        if self.sensor_name == "uv_category" and value is not None:
+            value = value.replace("veryhigh", "very high").title()
+        # Strip trailing period from short_text for cleaner display
+        elif self.sensor_name == "short_text" and isinstance(value, str):
+            value = value.rstrip(".")
+
+        if isinstance(value, str) and len(value) > MAX_STATE_LENGTH:
+            value = value[:MAX_STATE_LENGTH] + "..."
+        return value
 
     @property
     def name(self) -> str:
@@ -431,15 +475,12 @@ class NowLaterSensor(SensorBase):
         return dict(self.collector.daily_forecasts_data["metadata"])
 
     @property
-    def state(self) -> Any:
-        """Return the state of the sensor."""
-        if not self.collector.daily_forecasts_data or "data" not in self.collector.daily_forecasts_data:
-            return None
-        data = self.collector.daily_forecasts_data["data"]
+    def native_value(self) -> Any:
+        """Return the value reported by the sensor."""
+        data = (self.collector.daily_forecasts_data or {}).get("data")
         if not data:
             return None
-        self.current_state = data[0].get(self.sensor_name)
-        return self.current_state
+        return data[0].get(self.sensor_name) if isinstance(data[0], dict) else None
 
     @property
     def name(self) -> str:
@@ -485,8 +526,8 @@ class WarningsSensor(SensorBase):
         return attr
 
     @property
-    def state(self) -> int:
-        """Return the state of the sensor (count of active warnings).
+    def native_value(self) -> int:
+        """Return the count of active warnings.
 
         Reports 0 rather than None when there is no warnings data, so the state
         stays numeric for template arithmetic and history graphs. A BOM outage


### PR DESCRIPTION
Moves the 33 non-timestamp sensors off the `state` override and onto
`native_value`. The four `TIMESTAMP` forecast sensors are deliberately left
behind for a release of their own, because migrating them is breaking.

**This is maintainability work, with no user-visible change.** Every install is
Australian and metric, so no unit conversion fires, and no
`suggested_display_precision` is declared anywhere. Sensor values are unchanged.

## Why

`SensorEntity.state` is decorated `@final`. Overriding it bypasses everything
the sensor platform does between `native_value` and the state machine, and
blocks ever adopting `suggested_display_precision` — which BOM's inconsistent
decimal places make a genuine future want.

## What changed

- `ObservationSensor`, `NowLaterSensor` and `WarningsSensor` implement
  `native_value`; their `state` overrides are gone.
- `ForecastSensor` keeps a `state` override **narrowed to the `TIMESTAMP`
  branch**, delegating everything else via `super().state`. Those four still
  report local-time ISO strings. Phase 2 ships by deleting that one property.
- The `current_state` side effect is untangled. `ForecastSensor` wrote it in
  `state` and read it in `extra_state_attributes`, which only worked because
  Home Assistant happens to read the state before the attributes, and left stale
  values behind on the paths that returned early. The fire danger colours now
  come straight from the forecast data.
- Guards added on the remaining bare subscripts (`date`, `extended_text`,
  `station`, the temperature values), per the null-heavy API.

## One real bug found, in its own commit

When BOM omits the wind or gust block, the collector filled
`wind_speed_kilometre`, `wind_speed_knot`, `gust_speed_kilometre` and
`gust_speed_knot` with the string `"unavailable"`. Those are `WIND_SPEED` with a
unit, so they are numeric-expected: `SensorEntity.state` raises `ValueError` on
all four, and this migration would have broken them during exactly the API gap
the placeholder exists to handle. The `state` override had been passing the
string through to the state machine, where it also collided with Home
Assistant's reserved `unavailable` state.

Now `None`, which surfaces as `unknown`. `weather.py` needed this anyway — it
reads two of those fields as `float | None`. `wind_direction` is a plain string
sensor and keeps its existing value, so templates reading it are unaffected.

## Verification

There is no test suite, so this was checked with a throwaway harness: every
sensor key across seven collector states, comparing the old `state` against the
new code's `.state` driven through the real Home Assistant 2025.11.0
`SensorEntity.state`.

**240 readings — 222 identical, 18 differing in one deliberate case, 0
unexpected, nothing raising.** The four `TIMESTAMP` sensors still emit
local-offset ISO (`2026-07-30T09:40:00+10:00`), confirming Phase 2 is genuinely
deferred. Both wind speed sensors are unchanged (`7 km/h` and `4 kn` in,
identical out).

## Two judgment calls to review

1. **Forecast sensors are decoupled from `locations_data`** — these are all 18
   differences. The old `state` returned `None` for e.g. `temp_max` whenever the
   locations endpoint was unavailable, though only the timezone-dependent
   readings ever needed it. Better in a degraded state, but it is a behaviour
   change.
2. **`suggested_display_precision` was deliberately not added.** It is
   user-visible and this change was meant to be inert. Worth doing on its own
   now that it is finally possible.
