### PR TITLE
fix: report the UV and sunrise/sunset sensors as UTC timestamps

### DIFF
--- a/custom_components/ha_bom_australia/sensor.py
+++ b/custom_components/ha_bom_australia/sensor.py
@@ -401,38 +401,24 @@ class ForecastSensor(SensorBase):
         )
 
     @property
-    def state(self) -> Any:
-        """Return the state of the sensor.
-
-        Only the TIMESTAMP sensors are served here; everything else delegates to
-        SensorEntity.state, which reads native_value. Those four still report an
-        ISO 8601 string in the location's local time. Returning a datetime from
-        native_value instead — what a TIMESTAMP sensor is documented to do —
-        makes Home Assistant re-render the state in UTC, which breaks templates
-        that compare or slice the string, so it is held for a release of its own.
-        """
-        if self.device_class != SensorDeviceClass.TIMESTAMP:
-            return super().state
-
-        day_data = self._day_forecast()
-        if day_data is None:
-            return None
-        value = day_data.get(self.sensor_name)
-        tzinfo = self._timezone()
-        if tzinfo is None:
-            return value
-        try:
-            return parse_iso_datetime(value).astimezone(tzinfo).isoformat()
-        except ValueError:
-            return value
-
-    @property
     def native_value(self) -> Any:
         """Return the value reported by the sensor."""
         # If there is no data for this day, report no value for this day.
         day_data = self._day_forecast()
         if day_data is None:
             return None
+
+        if self.device_class == SensorDeviceClass.TIMESTAMP:
+            # A TIMESTAMP sensor must hand Home Assistant a timezone-aware
+            # datetime, which it then renders as UTC. Anything else — a missing
+            # value, or a string BOM has changed the format of — raises out of
+            # SensorEntity.state, so it has to become None here instead.
+            # parse_iso_datetime stamps UTC on an offset-less timestamp, which
+            # keeps a naive datetime from ever reaching that check.
+            try:
+                return parse_iso_datetime(day_data.get(self.sensor_name))
+            except ValueError:
+                return None
 
         if self.sensor_name == "uv_forecast":
             return self._uv_forecast(day_data)


### PR DESCRIPTION
Finishes the move off the `state` override. `ObservationSensor`, `NowLaterSensor`,
`WarningsSensor` and the non-timestamp forecast path went across in #77; this is the
last four, and there is now **no `state` override anywhere in the integration**.

`SensorEntity.state` is decorated `@final`, so overriding it bypassed everything the
sensor platform does between `native_value` and the state machine. `native_value` now
returns the timezone-aware `datetime` a `TIMESTAMP` sensor is documented to return and
Home Assistant renders it.

Affects `uv_start_time`, `uv_end_time`, `astronomical_sunrise_time` and
`astronomical_sunset_time`.

## What changes for users

The state text moves from local time to UTC:

```
before  2026-07-30T07:25:47+10:00
after   2026-07-29T21:25:47+00:00
```

**These are the same instant, and the old text was not wrong.** `+10:00` labels the
zone the reading is already in, so it did read 7:25 am local — it is not an
instruction to add ten hours. BOM publishes these fields in UTC to begin with
(`"sunrise_time": "2022-10-06T20:57:40Z"`), so this is the integration no longer
converting them rather than converting them to something new.

Displayed times are unchanged. A `TIMESTAMP` state is parsed and formatted in the
viewer's timezone, and both strings parse to the same instant, so cards, more-info and
the logbook read identically before and after.

What does break is narrow: templates that slice or string-compare the state text, e.g.
`states('sensor...')[11:16]` to pull out the time. `as_datetime` and `as_timestamp` are
unaffected. One caveat — the recorder stores the state text, so history rows written
before the upgrade keep the old format.

## Two inconsistencies fixed along the way

- **Unparseable values now report `unknown`** instead of reaching the state machine as
  raw text. This is no longer a cosmetic choice: Home Assistant raises `ValueError` on
  anything that is not a `datetime`, so the fallback has to be `None`.
- **The state format no longer flips during a `locations` outage.** Localising to the
  forecast location's timezone is gone, since Home Assistant re-normalises to UTC
  regardless. That had coupled these four sensors to the `locations` endpoint, whose
  failure made them fall back to BOM's raw `Z` string for the duration.

## Verification

No test suite, so this was checked with two throwaway harnesses that execute real
shipped source rather than re-implementations — Home Assistant's `TIMESTAMP` block
`exec`'d out of `homeassistant/components/sensor/__init__.py` (2025.11.0), and both
sides of the sensor code pulled from `main` and this branch with `ast`.

- **88 timestamp readings** — 11 collector states × 4 sensors × 2 day indices:
  58 identical, 30 differing, **0 raising**. The 58 are exactly the no-data cases
  (44 past the end of the forecast, 12 across three outage states, 2 null UV times).
  Every one of the 30 is the intended UTC re-render, plus the junk fixtures
  (`'6:12am'`, `''`, an int, a dict) that used to pass through as text.
- **78 non-timestamp readings** across 13 forecast keys: **0 differences.** Worth
  checking, because the new branch sits above the `uv_forecast` branch in
  `native_value` — the UV summary string still renders local times.

`ruff` clean.

## Release note

Suggest a **minor** bump. The state format change is real but nothing users look at
moves, so this does not warrant a major:

> The UV protection and sunrise/sunset sensors now report their state as a UTC
> timestamp, which is what Home Assistant expects of a timestamp sensor. The times
> themselves have not changed and neither has anything on your dashboard — only the
> text of the state, from `2026-07-30T07:25:47+10:00` to `2026-07-29T21:25:47+00:00`.
> Templates using `as_datetime` or `as_timestamp` need no change. Templates that slice
> or string-compare these states need to convert to local time first.
