### PR TITLE
feat: add a Road Weather Alert warning binary sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Individual binary sensors for different warning types (matching BOM API):
 - Bushwalkers Alert
 - Fire Weather Warning
 - Tropical Cyclone Warning
+- Road Weather Alert
 
 Each binary sensor includes:
 - On/off state based on active warnings (excludes only cancelled warnings)
@@ -73,6 +74,11 @@ Each binary sensor includes:
 - Severity and warning group type in attributes
 - Issue and expiry times
 - Detailed warning information
+
+New warning types are off by default on existing installations, because the
+selection made during setup is stored with the config entry. To pick up a
+warning type added by a later release, open the integration's `Configure`
+dialog and tick it on the warning sensors page.
 
 ### 3. Sensors (Observations & Forecasts)
 Regular sensors for:

--- a/api doc/API.md
+++ b/api doc/API.md
@@ -325,12 +325,12 @@ The following table shows all known BOM warning types and their support status i
 | `hazardous_surf_warning` | ✅ Supported | Hazardous Surf Warning |
 | `heatwave_warning` | ✅ Supported | Heatwave Warning |
 | `marine_wind_warning` | ✅ Supported | Marine Wind Warning |
+| `road_weather_alert` | ✅ Supported | Road Weather Alert |
 | `severe_thunderstorm_warning` | ✅ Supported | Severe Thunderstorm Warning |
 | `severe_weather_warning` | ✅ Supported | Severe Weather Warning |
 | `sheep_graziers_warning` | ✅ Supported | Sheep Graziers Warning |
 | `tropical_cyclone_warning` | ✅ Supported | Tropical Cyclone Warning |
 | `squall_warning` | ❌ Not Supported | Squall Warning |
-| `road_weather_alert` | ❌ Not Supported | Road Weather Alert |
 | `coastal_hazard_warning` | ❌ Not Supported | Coastal Hazard Warning |
 | `ocean_wind_warning` | ❌ Not Supported | Ocean Wind Warning |
 | `tsunami_alert` | ❌ Not Supported | Tsunami Alert |

--- a/custom_components/ha_bom_australia/const.py
+++ b/custom_components/ha_bom_australia/const.py
@@ -366,4 +366,5 @@ WARNING_TYPES: Final = {
     "bushwalkers_alert": {"name": "Bushwalkers Alert", "icon": "mdi:hiking"},
     "fire_weather_warning": {"name": "Fire Weather Warning", "icon": "mdi:fire-alert"},
     "tropical_cyclone_warning": {"name": "Tropical Cyclone Warning", "icon": "mdi:weather-hurricane"},
+    "road_weather_alert": {"name": "Road Weather Alert", "icon": "mdi:road-variant"},
 }

--- a/custom_components/ha_bom_australia/strings.json
+++ b/custom_components/ha_bom_australia/strings.json
@@ -80,7 +80,8 @@
           "frost_warning": "Frost Warning",
           "bushwalkers_alert": "Bushwalkers Alert",
           "fire_weather_warning": "Fire Weather Warning",
-          "tropical_cyclone_warning": "Tropical Cyclone Warning"
+          "tropical_cyclone_warning": "Tropical Cyclone Warning",
+          "road_weather_alert": "Road Weather Alert"
         }
       },
       "forecasts_monitored": {
@@ -195,7 +196,8 @@
           "frost_warning": "Frost Warning",
           "bushwalkers_alert": "Bushwalkers Alert",
           "fire_weather_warning": "Fire Weather Warning",
-          "tropical_cyclone_warning": "Tropical Cyclone Warning"
+          "tropical_cyclone_warning": "Tropical Cyclone Warning",
+          "road_weather_alert": "Road Weather Alert"
         }
       },
       "forecasts_monitored": {

--- a/custom_components/ha_bom_australia/translations/en.json
+++ b/custom_components/ha_bom_australia/translations/en.json
@@ -80,7 +80,8 @@
           "frost_warning": "Frost Warning",
           "bushwalkers_alert": "Bushwalkers Alert",
           "fire_weather_warning": "Fire Weather Warning",
-          "tropical_cyclone_warning": "Tropical Cyclone Warning"
+          "tropical_cyclone_warning": "Tropical Cyclone Warning",
+          "road_weather_alert": "Road Weather Alert"
         }
       },
       "forecasts_monitored": {
@@ -195,7 +196,8 @@
           "frost_warning": "Frost Warning",
           "bushwalkers_alert": "Bushwalkers Alert",
           "fire_weather_warning": "Fire Weather Warning",
-          "tropical_cyclone_warning": "Tropical Cyclone Warning"
+          "tropical_cyclone_warning": "Tropical Cyclone Warning",
+          "road_weather_alert": "Road Weather Alert"
         }
       },
       "forecasts_monitored": {

--- a/info.md
+++ b/info.md
@@ -23,7 +23,7 @@ A comprehensive weather entity that combines both daily and hourly forecasts in 
 
 ### 2. Binary Sensors (Warnings)
 Individual binary sensors for different warning types (matching BOM API):
-- Flood Watch, Flood Warning, Sheep Graziers Warning, Severe Thunderstorm Warning, Severe Weather Warning, Marine Wind Warning, Hazardous Surf Warning, Heatwave Warning, Frost Warning, Bushwalkers Alert, Fire Weather Warning, Tropical Cyclone Warning
+- Flood Watch, Flood Warning, Sheep Graziers Warning, Severe Thunderstorm Warning, Severe Weather Warning, Marine Wind Warning, Hazardous Surf Warning, Heatwave Warning, Frost Warning, Bushwalkers Alert, Fire Weather Warning, Tropical Cyclone Warning, Road Weather Alert
 - Each sensor includes on/off state, severity information, issue/expiry times, and detailed warning data
 
 ### 3. Sensors (Observations & Forecasts)


### PR DESCRIPTION
Closes #64.

BOM issues `road_weather_alert` warnings for fog, ice and similar road hazards. They were already arriving in the warnings payload and showing up as attributes on the aggregate warnings sensor, but there was no dedicated binary sensor for them. This adds one.

The API type string is taken verbatim from the live Victorian alert captured in the issue:

```yaml
id: VIC_ME009_IDV30000
area_id: VIC_ME009
type: road_weather_alert
title: Road Weather Alert for Victoria
short_title: Road Weather Alert
state: VIC
warning_group_type: major
issue_time: "2026-08-15T19:58:20Z"
expiry_time: "2026-08-16T03:58:20Z"
phase: new
```

`WARNING_TYPES` in `const.py` is the single source of truth here, so the one-line entry is enough to wire up the entity, the setup and options flow checkboxes, and the entity-registry pruning on unload. The rest of the diff is the display strings and documentation.

## Changes

- `const.py` — `road_weather_alert` entry in `WARNING_TYPES`, icon `mdi:road-variant`
- `strings.json` and `translations/en.json` — label for the checkbox in both the config and options flows
- `api doc/API.md` — moved from Not Supported to Supported in the warning types table
- `README.md` and `info.md` — added to the list of warning binary sensors

## Upgrade behaviour

The warning selection is stored with the config entry, so existing installations will not pick the new sensor up automatically — it has to be ticked on in the integration's Configure dialog. That is how every previously added warning type has behaved, and it is not distinguishable from a user having deliberately unticked something, so I left the behaviour alone and documented it in the README instead.