### PR TITLE
chore: move actions/checkout to v7 for Node 24

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -11,7 +11,7 @@ jobs:
     name: Validate with hassfest
     steps:
       - name: Checkout repository
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
 
       - name: Run hassfest
         uses: "home-assistant/actions/hassfest@master"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Needed so the existing tags are available to check against.
           fetch-depth: 0


### PR DESCRIPTION
`actions/checkout@v4` declares `node20` as its runtime, which GitHub has deprecated, so both the Release workflow and Hassfest emit a deprecation warning on every run. `actions/checkout@v7` declares `node24`.

Nothing in either workflow is affected by the behaviour changes across the intervening majors. v6 moved the persisted credentials out of `.git/config` and into a separate file, which the release job's `git push --atomic` still authenticates against, and v7 only blocks fork PR checkouts under `pull_request_target` and `workflow_run` — this repository uses neither trigger.

The other two actions in use, `home-assistant/actions/hassfest@master` and `hacs/action@main`, are Docker actions rather than JavaScript ones, so they have no Node runtime to deprecate and need no change.